### PR TITLE
Fix render matrix for `VelloScene`s in Bevy UI nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+### Added
+
+- New `scene-ui` example demonstrating a `VelloScene` attached to a `bevy::ui::Node`
+
+### Fixed
+
+- `VelloScene` components on `bevy::ui::Node` entities now account for Bevy's UI layout systems and render at the expected viewport coordinates
+
 ## 0.4.2
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "examples/scene",
   "examples/svg",
   "examples/lottie",
+  "examples/scene-ui",
 ]
 
 [workspace.package]

--- a/examples/scene-ui/Cargo.toml
+++ b/examples/scene-ui/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "scene-ui"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+bevy_vello = { path = "../../" }
+bevy = { workspace = true }

--- a/examples/scene-ui/src/main.rs
+++ b/examples/scene-ui/src/main.rs
@@ -36,7 +36,6 @@ fn setup_ui(mut commands: Commands) {
     ));
 }
 
-#[allow(clippy::type_complexity)]
 fn update_ui(mut query: Query<(&Node, &Interaction, &mut VelloScene)>) {
     let Ok((node, interaction, mut scene)) = query.get_single_mut() else {
         return;

--- a/examples/scene-ui/src/main.rs
+++ b/examples/scene-ui/src/main.rs
@@ -1,0 +1,113 @@
+use std::f64::consts::{FRAC_PI_4, SQRT_2};
+
+use bevy::prelude::*;
+use bevy_vello::{prelude::*, VelloPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(VelloPlugin)
+        .add_systems(Startup, setup_ui)
+        .add_systems(Update, update_ui)
+        .run();
+}
+
+fn setup_ui(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+
+    let one_third = Val::Percent(100.0 / 3.0);
+    commands.spawn((
+        NodeBundle {
+            style: Style {
+                position_type: PositionType::Absolute,
+                left: one_third,
+                top: one_third,
+                width: one_third,
+                height: one_third,
+                border: UiRect::all(Val::Px(2.0)),
+                ..default()
+            },
+            border_color: Color::FUCHSIA.with_a(0.5).into(),
+            ..default()
+        },
+        Interaction::default(),
+        VelloScene::default(),
+        CoordinateSpace::ScreenSpace,
+    ));
+}
+
+#[allow(clippy::type_complexity)]
+fn update_ui(mut query: Query<(&Node, &Interaction, &mut VelloScene)>) {
+    let Ok((node, interaction, mut scene)) = query.get_single_mut() else {
+        return;
+    };
+
+    let size = node.size();
+    let dmin = f32::min(size.x, size.y);
+    let radius = (dmin / 2.0) as f64;
+
+    let center = size / 2.0;
+    let center = kurbo::Point::from((center.x as f64, center.y as f64));
+
+    *scene = VelloScene::default();
+
+    match *interaction {
+        Interaction::Hovered | Interaction::Pressed => {
+            let color = match *interaction {
+                Interaction::Hovered => peniko::Color::GREEN,
+                Interaction::Pressed => peniko::Color::rgba8(0, 110, 0, 255),
+                _ => unreachable!(),
+            };
+
+            scene.fill(
+                peniko::Fill::NonZero,
+                kurbo::Affine::default(),
+                color,
+                None,
+                &kurbo::Circle::new(center, radius),
+            );
+            scene.fill(
+                peniko::Fill::NonZero,
+                kurbo::Affine::rotate_about(FRAC_PI_4, center)
+                    .then_translate(kurbo::Vec2::new(SQRT_2 / 2.0, SQRT_2 / 2.0) * radius * 0.2)
+                    .then_translate(kurbo::Vec2::new(0.0, radius * -0.1)),
+                peniko::Color::WHITE,
+                None,
+                &kurbo::Rect::from_center_size(center, (radius * 0.2, radius)),
+            );
+            scene.fill(
+                peniko::Fill::NonZero,
+                kurbo::Affine::rotate_about(-FRAC_PI_4, center)
+                    .then_translate(kurbo::Vec2::new(SQRT_2 / -2.0, SQRT_2 / -2.0) * radius * 0.1)
+                    .then_translate(kurbo::Vec2::new(SQRT_2 / -2.0, SQRT_2 / 2.0) * radius * 0.4)
+                    .then_translate(kurbo::Vec2::new(0.0, radius * -0.1)),
+                peniko::Color::WHITE,
+                None,
+                &kurbo::Rect::from_center_size(center, (radius * 0.2, radius * 0.5)),
+            );
+        }
+        Interaction::None => {
+            scene.fill(
+                peniko::Fill::NonZero,
+                kurbo::Affine::default(),
+                peniko::Color::RED,
+                None,
+                &kurbo::Circle::new(center, radius),
+            );
+            scene.fill(
+                peniko::Fill::NonZero,
+                kurbo::Affine::rotate_about(FRAC_PI_4, center),
+                peniko::Color::WHITE,
+                None,
+                &kurbo::Rect::from_center_size(center, (radius * 0.2, radius * 1.25)),
+            );
+            scene.fill(
+                peniko::Fill::NonZero,
+                kurbo::Affine::rotate_about(-FRAC_PI_4, center),
+                peniko::Color::WHITE,
+                None,
+                &kurbo::Rect::from_center_size(center, (radius * 0.2, radius * 1.25)),
+            );
+        }
+    }
+}

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -136,6 +136,7 @@ pub struct ExtractedRenderScene {
     pub scene: VelloScene,
     pub transform: GlobalTransform,
     pub render_mode: CoordinateSpace,
+    pub ui_node: Option<Node>,
 }
 
 pub fn scene_instances(
@@ -147,10 +148,11 @@ pub fn scene_instances(
             &GlobalTransform,
             &ViewVisibility,
             &InheritedVisibility,
+            Option<&Node>,
         )>,
     >,
 ) {
-    for (scene, coord_space, transform, view_visibility, inherited_visibility) in
+    for (scene, coord_space, transform, view_visibility, inherited_visibility, ui_node) in
         query_scenes.iter()
     {
         if view_visibility.get() && inherited_visibility.get() {
@@ -158,6 +160,7 @@ pub fn scene_instances(
                 transform: *transform,
                 render_mode: *coord_space,
                 scene: scene.clone(),
+                ui_node: ui_node.cloned(),
             });
         }
     }

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -158,7 +158,7 @@ pub fn prepare_scene_affines(
 
         let raw_transform = match render_scene.render_mode {
             CoordinateSpace::ScreenSpace => {
-                let mut raw_transform = world_transform.compute_matrix().mul_scalar(pixel_scale.0);
+                let mut model_matrix = world_transform.compute_matrix().mul_scalar(pixel_scale.0);
 
                 if let Some(node) = &render_scene.ui_node {
                     // The Bevy Transform for a UI node seems to always have the origin
@@ -167,16 +167,16 @@ pub fn prepare_scene_affines(
                     // shape with center=(20,20) inside of a 40x40 UI node results in
                     // the shape being centered within the node.
                     let Vec2 { x, y } = node.size() * pixel_scale.0;
-                    raw_transform.w_axis.x -= x / 2.0;
-                    raw_transform.w_axis.y -= y / 2.0;
+                    model_matrix.w_axis.x -= x / 2.0;
+                    model_matrix.w_axis.y -= y / 2.0;
 
                     // Note that there's no need to flip the Y axis in this case, as
                     // Bevy handles it for us.
                 } else {
-                    raw_transform.w_axis.y *= -1.0;
+                    model_matrix.w_axis.y *= -1.0;
                 }
 
-                raw_transform
+                model_matrix
             }
             CoordinateSpace::WorldSpace => {
                 let mut model_matrix = world_transform.compute_matrix();


### PR DESCRIPTION
This PR fixes a couple issues I had when trying to use a `VelloScene` with Bevy's UI:

1. The Y-axis was flipped, so that setting any `top` or `bottom` value on the `Style` component caused the `VelloScene` to move in the opposite direction from the node
2. Bevy's layout system puts the transform origin at the center of the node's computed bounding box, which is awkward for a canvas-like API where you expect to be issuing draw commands with the origin at the bounding box corner.

That said, I know there are different conventions for whether the Y-origin is top or bottom, and I'm honestly not sure where Vello's origin is under normal circumstances. Let me know if you'd like to preserve a bottom-left origin for Vello drawing commands while still positioning the Vello scene so that it aligns with the Bevy node &mdash; it shouldn't be overly difficult to make that adjustment.

I haven't tested this super exhaustively, but I did verify that the original "scene" example still works as expected, and added a new "scene-ui" example for testing the changes made here. Let me know if you have any questions, concerns, or would like to see any changes!