### PR TITLE
v0.5.0 - Update to bevy 0.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       run: cargo clippy -- -D warnings
 
     - name: Build | Rustfmt
-      run: cargo fmt --all -- --check
+      run: cargo fmt -- --check
 
   check:
     runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Build | Check (native)
-      run: cargo check --all
+      run: cargo check
 
     - name: Build | Check (wasm)
       run: cargo check --target wasm32-unknown-unknown
@@ -70,7 +70,7 @@ jobs:
       uses: Swatinem/rust-cache@v2.7.3
 
     - name: Build | Test (native)
-      run: cargo test --all
+      run: cargo test
 
     - name: Build | Test (wasm)
       run: wasm-pack test --node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ### Fixed
 
+- Removed `Arc` in another `Arc` for `VelloFont`
 - Opacity now correctly applies to SVG assets.
 - Opacity now applies correctly to the lottie image group, rather than each element and path within it, causing overdraw.
 - `VelloScene` components on `bevy::ui::Node` entities now account for Bevy's UI layout systems and render at the expected viewport coordinates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ### Added
 
-- New `scene-ui` example demonstrating a `VelloScene` attached to a `bevy::ui::Node`
+- New `scene_ui` example demonstrating a `VelloScene` attached to a `bevy::ui::Node`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ### Added
 
-- New `scene_ui` example demonstrating a `VelloScene` attached to a `bevy::ui::Node`
+- New `scene_ui` example demonstrating a `VelloScene` attached to a `bevy::ui::Node`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 - `VelloScene` components on `bevy::ui::Node` entities now account for Bevy's UI layout systems and render at the expected viewport coordinates
 
+### Removed
+
+- Pancam and/or egui from all examples besides the demo, as external dependencies can bottleneck upgrading to the next bevy version.
+
 ## 0.4.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ### Fixed
 
+- Opacity now correctly applies to SVG assets.
+- Opacity now applies correctly to the lottie image group, rather than each element and path within it, causing overdraw.
 - `VelloScene` components on `bevy::ui::Node` entities now account for Bevy's UI layout systems and render at the expected viewport coordinates
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,18 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+## 0.5.0
+
 ### Added
 
 - New `scene_ui` example demonstrating a `VelloScene` attached to a `bevy::ui::Node`
+
+### Changed
+
+- Updated to bevy 0.14
+- Updated to vello 0.2
+- Updated to velato 0.3
+- Updated to vello_svg 0.3
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.4.2"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/linebender/bevy_vello"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
   "examples/scene",
   "examples/svg",
   "examples/lottie",
-  "examples/scene-ui",
+  "examples/scene_ui",
 ]
 
 [workspace.package]
@@ -19,14 +19,14 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/linebender/bevy_vello"
 
 [workspace.dependencies]
-bevy = { version = "0.13.0", default-features = false, features = [
+bevy = { version = "0.14.0-rc.4", default-features = false, features = [
   "bevy_asset",
   "bevy_winit",
   "bevy_core_pipeline",
   "bevy_pbr",
   "bevy_render",
   "bevy_ui",
-  "multi-threaded",
+  "multi_threaded",
   "x11",
   "tonemapping_luts",
   "bevy_gizmos",
@@ -50,9 +50,10 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bevy = { workspace = true }
-vello = "0.1.0"
-vello_svg = "0.2.0"
-velato = "0.2.0"
+vello = "0.2.0"
+vello_svg = "0.3.0"
+velato = "0.3.0"
+thiserror = "1.0.61"
 once_cell = "1.19.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/linebender/bevy_vello"
 
 [workspace.dependencies]
-bevy = { version = "0.14.0-rc.4", default-features = false, features = [
+bevy = { version = "0.14.0", default-features = false, features = [
   "bevy_asset",
   "bevy_winit",
   "bevy_core_pipeline",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Linebender Zulip](https://img.shields.io/badge/Linebender-%23gpu-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/197075-gpu)
 [![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
-[![Vello](https://img.shields.io/badge/vello-v0.1.0-purple.svg)](https://crates.io/crates/vello)
+[![Vello](https://img.shields.io/badge/vello-v0.2.0-purple.svg)](https://crates.io/crates/vello)
 [![Following released Bevy versions](https://img.shields.io/badge/bevy%20tracking-released%20version-lightblue)](https://bevyengine.org/learn/quick-start/plugin-development/#main-branch-tracking)\
 [![Dependency status](https://deps.rs/repo/github/linebender/bevy_vello/status.svg)](https://deps.rs/repo/github/linebender/bevy_vello)
 [![Crates.io](https://img.shields.io/crates/v/bevy_vello.svg)](https://crates.io/crates/bevy_vello)
@@ -29,7 +29,8 @@ cargo run -p demo
 
 |bevy|bevy_vello|
 |---|---|
-|0.13|0.1-0.4, main|
+|0.14|0.5, main|
+|0.13|0.1-0.4|
 |< 0.13| unsupported |
 
 ## Cargo features

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -11,4 +11,4 @@ publish = false
 bevy_vello = { path = "../../", features = ["experimental-dotLottie"] }
 bevy = { workspace = true }
 bevy_pancam = { version = "0.11", features = ["bevy_egui"] }
-bevy_egui = "0.25"
+bevy_egui = "0.28.0"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -12,4 +12,3 @@ bevy_vello = { path = "../../", features = ["experimental-dotLottie"] }
 bevy = { workspace = true }
 bevy_pancam = { version = "0.11", features = ["bevy_egui"] }
 bevy_egui = "0.25"
-console_error_panic_hook = "0.1"

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -8,14 +8,16 @@ use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(AssetMetaCheck::Never)
-        .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin)
-        .add_plugins(VelloPlugin)
-        .init_resource::<EmbeddedAssetRegistry>()
-        .add_plugins(bevy_pancam::PanCamPlugin)
-        .add_systems(Startup, setup_vector_graphics)
-        .add_systems(Update, (print_metadata, ui::controls_ui));
+    app.add_plugins(DefaultPlugins.set(AssetPlugin {
+        meta_check: AssetMetaCheck::Never,
+        ..default()
+    }))
+    .add_plugins(EguiPlugin)
+    .add_plugins(VelloPlugin)
+    .init_resource::<EmbeddedAssetRegistry>()
+    .add_plugins(bevy_pancam::PanCamPlugin)
+    .add_systems(Startup, setup_vector_graphics)
+    .add_systems(Update, (print_metadata, ui::controls_ui));
     embedded_asset!(app, "assets/calendar.json");
     app.run();
 }

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     .add_plugins(EguiPlugin)
     .add_plugins(VelloPlugin)
     .init_resource::<EmbeddedAssetRegistry>()
-    .add_plugins(bevy_pancam::PanCamPlugin)
+    //.add_plugins(bevy_pancam::PanCamPlugin)
     .add_systems(Startup, setup_vector_graphics)
     .add_systems(Update, (print_metadata, ui::controls_ui));
     embedded_asset!(app, "assets/calendar.json");
@@ -25,7 +25,8 @@ fn main() {
 }
 
 fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServer>) {
-    commands.spawn((Camera2dBundle::default(), bevy_pancam::PanCam::default()));
+    commands.spawn(Camera2dBundle::default());
+    //commands.spawn((Camera2dBundle::default(), bevy_pancam::PanCam::default()));
     commands
         .spawn(VelloAssetBundle {
             vector: asset_server.load::<VelloAsset>("embedded://demo/assets/calendar.json"),
@@ -42,7 +43,7 @@ fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServe
                             autoplay: false,
                             ..default()
                         })
-                        .theme(Theme::new().add("calendar", css::BLUE.into()))
+                        .theme(Theme::new().add("calendar", css::YELLOW.into()))
                         .transition(PlayerTransition::OnMouseEnter { state: "play" })
                         .reset_playhead_on_start()
                 })
@@ -50,10 +51,10 @@ fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServe
                     PlayerState::new("play")
                         .playback_options(PlaybackOptions {
                             looping: PlaybackLoopBehavior::DoNotLoop,
-                            speed: 0.25,
+                            speed: 0.75,
                             ..default()
                         })
-                        .theme(Theme::new().add("calendar", css::GREEN.into()))
+                        .theme(Theme::new().add("calendar", css::LIME.into()))
                         .transition(PlayerTransition::OnMouseLeave { state: "rev" }),
                 )
                 .with_state(
@@ -61,7 +62,7 @@ fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServe
                         .playback_options(PlaybackOptions {
                             looping: PlaybackLoopBehavior::DoNotLoop,
                             direction: PlaybackDirection::Reverse,
-                            speed: 0.25,
+                            speed: 0.75,
                             ..default()
                         })
                         .theme(Theme::new().add("calendar", css::RED.into()))

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -1,8 +1,9 @@
 mod ui;
 
-use bevy::asset::io::embedded::EmbeddedAssetRegistry;
-use bevy::asset::{embedded_asset, AssetMetaCheck};
-use bevy::prelude::*;
+use bevy::{
+    asset::{embedded_asset, io::embedded::EmbeddedAssetRegistry, AssetMetaCheck},
+    prelude::*,
+};
 use bevy_egui::EguiPlugin;
 use bevy_vello::{prelude::*, VelloPlugin};
 

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -2,6 +2,7 @@ mod ui;
 
 use bevy::{
     asset::{embedded_asset, io::embedded::EmbeddedAssetRegistry, AssetMetaCheck},
+    color::palettes::css,
     prelude::*,
 };
 use bevy_egui::EguiPlugin;
@@ -41,7 +42,7 @@ fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServe
                             autoplay: false,
                             ..default()
                         })
-                        .theme(Theme::new().add("calendar", Color::BLUE))
+                        .theme(Theme::new().add("calendar", css::BLUE.into()))
                         .transition(PlayerTransition::OnMouseEnter { state: "play" })
                         .reset_playhead_on_start()
                 })
@@ -52,7 +53,7 @@ fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServe
                             speed: 0.25,
                             ..default()
                         })
-                        .theme(Theme::new().add("calendar", Color::GREEN))
+                        .theme(Theme::new().add("calendar", css::GREEN.into()))
                         .transition(PlayerTransition::OnMouseLeave { state: "rev" }),
                 )
                 .with_state(
@@ -63,7 +64,7 @@ fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServe
                             speed: 0.25,
                             ..default()
                         })
-                        .theme(Theme::new().add("calendar", Color::RED))
+                        .theme(Theme::new().add("calendar", css::RED.into()))
                         .transition(PlayerTransition::OnMouseEnter { state: "play" })
                         .transition(PlayerTransition::OnComplete { state: "stopped" }),
                 ),

--- a/examples/demo/src/ui.rs
+++ b/examples/demo/src/ui.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_egui::{
-    egui::{self},
+    egui::{self, Color32},
     EguiContexts,
 };
 use bevy_vello::{prelude::*, vello_svg::usvg::strict_num::Ulps};
@@ -48,6 +48,11 @@ pub fn controls_ui(
                 player.pause();
                 playhead.seek(frame);
             };
+            if player.is_stopped() {
+                ui.colored_label(Color32::RED, "stopped");
+            } else if !player.is_playing() {
+                ui.colored_label(Color32::YELLOW, "paused");
+            }
         });
 
         ui.horizontal_wrapped(|ui| {
@@ -245,21 +250,22 @@ pub fn controls_ui(
         ui.heading("Theme");
         for layer in composition.as_ref().get_layers() {
             let color = theme.get_mut(layer).cloned().unwrap_or_default();
-            let color = color.to_linear();
-            let mut color_edit = [color.red, color.green, color.blue, color.alpha];
+            let color = color.to_srgba().to_u8_array();
+            let mut color32 =
+                Color32::from_rgba_unmultiplied(color[0], color[1], color[2], color[3]);
             ui.horizontal(|ui| {
-                if ui
-                    .color_edit_button_rgba_unmultiplied(&mut color_edit)
-                    .changed()
-                {
-                    let [r, g, b, a] = color_edit;
+                if ui.color_edit_button_srgba(&mut color32).changed() {
+                    let r = color32.r();
+                    let g = color32.g();
+                    let b = color32.b();
+                    let a = color32.a();
                     player
                         .state_mut()
                         .theme
                         .as_mut()
                         .unwrap()
-                        .edit(layer, Color::linear_rgba(r, g, b, a));
-                    theme.edit(layer, Color::linear_rgba(r, g, b, a));
+                        .edit(layer, Color::srgba_u8(r, g, b, a));
+                    theme.edit(layer, Color::srgba_u8(r, g, b, a));
                 };
                 ui.label(layer);
             });

--- a/examples/demo/src/ui.rs
+++ b/examples/demo/src/ui.rs
@@ -245,7 +245,7 @@ pub fn controls_ui(
         ui.heading("Theme");
         for layer in composition.as_ref().get_layers() {
             let color = theme.get_mut(layer).cloned().unwrap_or_default();
-            let color = color.to_srgba();
+            let color = color.to_linear();
             let mut color_edit = [color.red, color.green, color.blue, color.alpha];
             ui.horizontal(|ui| {
                 if ui
@@ -258,8 +258,8 @@ pub fn controls_ui(
                         .theme
                         .as_mut()
                         .unwrap()
-                        .edit(layer, Color::srgba(r, g, b, a));
-                    theme.edit(layer, Color::srgba(r, g, b, a));
+                        .edit(layer, Color::linear_rgba(r, g, b, a));
+                    theme.edit(layer, Color::linear_rgba(r, g, b, a));
                 };
                 ui.label(layer);
             });

--- a/examples/demo/src/ui.rs
+++ b/examples/demo/src/ui.rs
@@ -1,8 +1,9 @@
 use bevy::prelude::*;
-use bevy_egui::egui::{self};
-use bevy_egui::EguiContexts;
-use bevy_vello::prelude::*;
-use bevy_vello::vello_svg::usvg::strict_num::Ulps;
+use bevy_egui::{
+    egui::{self},
+    EguiContexts,
+};
+use bevy_vello::{prelude::*, vello_svg::usvg::strict_num::Ulps};
 use std::time::Duration;
 
 pub fn controls_ui(
@@ -244,7 +245,8 @@ pub fn controls_ui(
         ui.heading("Theme");
         for layer in composition.as_ref().get_layers() {
             let color = theme.get_mut(layer).cloned().unwrap_or_default();
-            let mut color_edit = [color.r(), color.g(), color.b(), color.a()];
+            let color = color.to_srgba();
+            let mut color_edit = [color.red, color.green, color.blue, color.alpha];
             ui.horizontal(|ui| {
                 if ui
                     .color_edit_button_rgba_unmultiplied(&mut color_edit)
@@ -256,8 +258,8 @@ pub fn controls_ui(
                         .theme
                         .as_mut()
                         .unwrap()
-                        .edit(layer, Color::rgba(r, g, b, a));
-                    theme.edit(layer, Color::rgba(r, g, b, a));
+                        .edit(layer, Color::srgba(r, g, b, a));
+                    theme.edit(layer, Color::srgba(r, g, b, a));
                 };
                 ui.label(layer);
             });

--- a/examples/drag_n_drop/src/main.rs
+++ b/examples/drag_n_drop/src/main.rs
@@ -4,11 +4,13 @@ use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(AssetMetaCheck::Never)
-        .add_plugins(DefaultPlugins)
-        .add_plugins(VelloPlugin)
-        .add_systems(Startup, setup_vector_graphics)
-        .add_systems(Update, drag_and_drop);
+    app.add_plugins(DefaultPlugins.set(AssetPlugin {
+        meta_check: AssetMetaCheck::Never,
+        ..default()
+    }))
+    .add_plugins(VelloPlugin)
+    .add_systems(Startup, setup_vector_graphics)
+    .add_systems(Update, drag_and_drop);
     embedded_asset!(app, "assets/fountain.svg");
     app.run();
 }

--- a/examples/drag_n_drop/src/main.rs
+++ b/examples/drag_n_drop/src/main.rs
@@ -1,5 +1,7 @@
-use bevy::asset::{embedded_asset, AssetMetaCheck};
-use bevy::prelude::*;
+use bevy::{
+    asset::{embedded_asset, AssetMetaCheck},
+    prelude::*,
+};
 use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {

--- a/examples/lottie/src/main.rs
+++ b/examples/lottie/src/main.rs
@@ -4,10 +4,12 @@ use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(AssetMetaCheck::Never)
-        .add_plugins(DefaultPlugins)
-        .add_plugins(VelloPlugin)
-        .add_systems(Startup, load_lottie);
+    app.add_plugins(DefaultPlugins.set(AssetPlugin {
+        meta_check: AssetMetaCheck::Never,
+        ..default()
+    }))
+    .add_plugins(VelloPlugin)
+    .add_systems(Startup, load_lottie);
     embedded_asset!(app, "assets/Tiger.json");
     app.run();
 }

--- a/examples/lottie/src/main.rs
+++ b/examples/lottie/src/main.rs
@@ -1,5 +1,7 @@
-use bevy::asset::{embedded_asset, AssetMetaCheck};
-use bevy::prelude::*;
+use bevy::{
+    asset::{embedded_asset, AssetMetaCheck},
+    prelude::*,
+};
 use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {

--- a/examples/scene/src/main.rs
+++ b/examples/scene/src/main.rs
@@ -1,6 +1,9 @@
 use bevy::prelude::*;
-use bevy_vello::vello::{kurbo, peniko};
-use bevy_vello::{prelude::*, VelloPlugin};
+use bevy_vello::{
+    prelude::*,
+    vello::{kurbo, peniko},
+    VelloPlugin,
+};
 
 fn main() {
     App::new()

--- a/examples/scene/src/main.rs
+++ b/examples/scene/src/main.rs
@@ -1,16 +1,14 @@
-use bevy::asset::AssetMetaCheck;
 use bevy::prelude::*;
 use bevy_vello::vello::{kurbo, peniko};
 use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {
     App::new()
-        .insert_resource(AssetMetaCheck::Never)
         .add_plugins(DefaultPlugins)
         .add_plugins(VelloPlugin)
         .add_systems(Startup, setup_vector_graphics)
         .add_systems(Update, simple_animation)
-        .run()
+        .run();
 }
 
 fn setup_vector_graphics(mut commands: Commands) {
@@ -21,7 +19,6 @@ fn setup_vector_graphics(mut commands: Commands) {
 fn simple_animation(mut query_scene: Query<(&mut Transform, &mut VelloScene)>, time: Res<Time>) {
     let sin_time = time.elapsed_seconds().sin().mul_add(0.5, 0.5);
     let (mut transform, mut scene) = query_scene.single_mut();
-
     // Reset scene every frame
     *scene = VelloScene::default();
 

--- a/examples/scene_ui/Cargo.toml
+++ b/examples/scene_ui/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "scene-ui"
+name = "scene_ui"
 version.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/examples/scene_ui/src/main.rs
+++ b/examples/scene_ui/src/main.rs
@@ -27,7 +27,7 @@ fn setup_ui(mut commands: Commands) {
                 border: UiRect::all(Val::Px(2.0)),
                 ..default()
             },
-            border_color: Color::FUCHSIA.with_a(0.5).into(),
+            border_color: Srgba::rgb(1.0, 0.0, 1.0).with_alpha(0.5).into(),
             ..default()
         },
         Interaction::default(),

--- a/examples/scene_ui/src/main.rs
+++ b/examples/scene_ui/src/main.rs
@@ -1,6 +1,6 @@
 use std::f64::consts::{FRAC_PI_4, SQRT_2};
 
-use bevy::prelude::*;
+use bevy::{color::palettes::css, prelude::*};
 use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {
@@ -27,7 +27,7 @@ fn setup_ui(mut commands: Commands) {
                 border: UiRect::all(Val::Px(2.0)),
                 ..default()
             },
-            border_color: Srgba::rgb(1.0, 0.0, 1.0).with_alpha(0.5).into(),
+            border_color: css::FUCHSIA.with_alpha(0.5).into(),
             ..default()
         },
         Interaction::default(),

--- a/examples/scene_ui/src/main.rs
+++ b/examples/scene_ui/src/main.rs
@@ -1,7 +1,6 @@
-use std::f64::consts::{FRAC_PI_4, SQRT_2};
-
 use bevy::{color::palettes::css, prelude::*};
 use bevy_vello::{prelude::*, VelloPlugin};
+use std::f64::consts::{FRAC_PI_4, SQRT_2};
 
 fn main() {
     App::new()

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -4,10 +4,12 @@ use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(AssetMetaCheck::Never)
-        .add_plugins(DefaultPlugins)
-        .add_plugins(VelloPlugin)
-        .add_systems(Startup, load_svg);
+    app.add_plugins(DefaultPlugins.set(AssetPlugin {
+        meta_check: AssetMetaCheck::Never,
+        ..default()
+    }))
+    .add_plugins(VelloPlugin)
+    .add_systems(Startup, load_svg);
     embedded_asset!(app, "assets/fountain.svg");
     app.run();
 }

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -1,5 +1,7 @@
-use bevy::asset::{embedded_asset, AssetMetaCheck};
-use bevy::prelude::*;
+use bevy::{
+    asset::{embedded_asset, AssetMetaCheck},
+    prelude::*,
+};
 use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {

--- a/examples/text/Cargo.toml
+++ b/examples/text/Cargo.toml
@@ -10,4 +10,3 @@ publish = false
 [dependencies]
 bevy_vello = { path = "../../" }
 bevy = { workspace = true }
-bevy_pancam = { version = "0.11", features = ["bevy_egui"] }

--- a/examples/text/src/main.rs
+++ b/examples/text/src/main.rs
@@ -1,8 +1,8 @@
-use bevy::asset::{embedded_asset, AssetMetaCheck};
-use bevy::prelude::*;
-use bevy_vello::text::VelloTextAlignment;
-use bevy_vello::vello::peniko;
-use bevy_vello::{prelude::*, VelloPlugin};
+use bevy::{
+    asset::{embedded_asset, AssetMetaCheck},
+    prelude::*,
+};
+use bevy_vello::{prelude::*, text::VelloTextAlignment, vello::peniko, VelloPlugin};
 
 fn main() {
     let mut app = App::new();

--- a/examples/text/src/main.rs
+++ b/examples/text/src/main.rs
@@ -6,21 +6,22 @@ use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(AssetMetaCheck::Never)
-        .add_plugins(DefaultPlugins)
-        .add_plugins(VelloPlugin)
-        .add_plugins(bevy_pancam::PanCamPlugin)
-        .add_systems(
-            Startup,
-            (setup_camera, setup_screenspace_text, setup_worldspace_text),
-        );
+    app.add_plugins(DefaultPlugins.set(AssetPlugin {
+        meta_check: AssetMetaCheck::Never,
+        ..default()
+    }))
+    .add_plugins(VelloPlugin)
+    .add_systems(
+        Startup,
+        (setup_camera, setup_screenspace_text, setup_worldspace_text),
+    );
     embedded_asset!(app, "assets/Rubik-Medium.ttf");
     embedded_asset!(app, "assets/Rubik-Medium.ttf");
     app.run();
 }
 
 fn setup_camera(mut commands: Commands) {
-    commands.spawn((Camera2dBundle::default(), bevy_pancam::PanCam::default()));
+    commands.spawn(Camera2dBundle::default());
 }
 
 fn setup_worldspace_text(mut commands: Commands, asset_server: ResMut<AssetServer>) {

--- a/examples/z_ordering/Cargo.toml
+++ b/examples/z_ordering/Cargo.toml
@@ -10,4 +10,3 @@ publish = false
 [dependencies]
 bevy_vello = { path = "../../" }
 bevy = { workspace = true }
-bevy_pancam = { version = "0.11", features = ["bevy_egui"] }

--- a/examples/z_ordering/src/main.rs
+++ b/examples/z_ordering/src/main.rs
@@ -1,7 +1,12 @@
-use bevy::asset::{embedded_asset, AssetMetaCheck};
-use bevy::prelude::*;
-use bevy_vello::vello::peniko::{Brush, Color};
-use bevy_vello::{prelude::*, VelloPlugin};
+use bevy::{
+    asset::{embedded_asset, AssetMetaCheck},
+    prelude::*,
+};
+use bevy_vello::{
+    prelude::*,
+    vello::peniko::{Brush, Color},
+    VelloPlugin,
+};
 
 fn main() {
     let mut app = App::new();

--- a/examples/z_ordering/src/main.rs
+++ b/examples/z_ordering/src/main.rs
@@ -5,25 +5,26 @@ use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(AssetMetaCheck::Never)
-        .add_plugins(DefaultPlugins)
-        .add_plugins(VelloPlugin)
-        .add_plugins(bevy_pancam::PanCamPlugin)
-        .add_systems(
-            Startup,
-            (
-                setup_camera,
-                setup_screenspace_vectors,
-                setup_worldspace_vectors,
-            ),
-        );
+    app.add_plugins(DefaultPlugins.set(AssetPlugin {
+        meta_check: AssetMetaCheck::Never,
+        ..default()
+    }))
+    .add_plugins(VelloPlugin)
+    .add_systems(
+        Startup,
+        (
+            setup_camera,
+            setup_screenspace_vectors,
+            setup_worldspace_vectors,
+        ),
+    );
     embedded_asset!(app, "assets/google_fonts/squid.json");
     embedded_asset!(app, "assets/fonts/Rubik-Medium.ttf");
     app.run();
 }
 
 fn setup_camera(mut commands: Commands) {
-    commands.spawn((Camera2dBundle::default(), bevy_pancam::PanCam::default()));
+    commands.spawn(Camera2dBundle::default());
 }
 
 fn setup_worldspace_vectors(mut commands: Commands, asset_server: ResMut<AssetServer>) {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -3,7 +3,7 @@ use crate::{
     text::VelloTextAlignment, CoordinateSpace, VelloAsset, VelloAssetAlignment, VelloFont,
     VelloText, ZFunction,
 };
-use bevy::{math::Vec3Swizzles, prelude::*};
+use bevy::{color::palettes::css, math::Vec3Swizzles, prelude::*};
 
 const RED_X_SIZE: f32 = 8.0;
 
@@ -150,7 +150,7 @@ fn render_text_debug(
                         }
                     };
                     let rect_center = origin + rect.size() / 2.0;
-                    gizmos.rect_2d(rect_center, 0.0, rect.size(), Color::WHITE);
+                    gizmos.rect_2d(rect_center, 0.0, rect.size(), css::WHITE);
                 }
                 CoordinateSpace::ScreenSpace => {
                     let Some(rect) = text.bb_in_screen_space(font, gtransform, camera, view) else {
@@ -200,7 +200,7 @@ fn render_text_debug(
                         rect_center,
                         0.0,
                         rect.size() * Vec2::new(1.0, 1.0),
-                        Color::WHITE,
+                        css::WHITE,
                     );
                 }
             }
@@ -213,12 +213,12 @@ fn draw_origin(gizmos: &mut Gizmos, projection: &OrthographicProjection, origin:
     let from = origin + RED_X_SIZE * Vec2::splat(1.0) * projection.scale;
     let to = origin + RED_X_SIZE * Vec2::splat(-1.0) * projection.scale;
 
-    gizmos.line_2d(from, to, Srgba::RED);
+    gizmos.line_2d(from, to, css::RED);
 
     let from = origin + RED_X_SIZE * Vec2::new(1.0, -1.0) * projection.scale;
     let to = origin + RED_X_SIZE * Vec2::new(-1.0, 1.0) * projection.scale;
 
-    gizmos.line_2d(from, to, Srgba::RED);
+    gizmos.line_2d(from, to, css::RED);
 }
 
 /// A helper method to draw the bounding box
@@ -231,25 +231,25 @@ fn draw_bounding_box(gizmos: &mut Gizmos, z_fn: &ZFunction, position: Vec2, size
     gizmos.line_2d(
         position + Vec2::new(-half_width, -half_height),
         position + Vec2::new(-half_width, half_height),
-        Color::WHITE,
+        css::WHITE,
     );
     // Top
     gizmos.line_2d(
         position + Vec2::new(-half_width, -half_height),
         position + Vec2::new(half_width, -half_height),
-        Color::WHITE,
+        css::WHITE,
     );
     // Right
     gizmos.line_2d(
         position + Vec2::new(half_width, -half_height),
         position + Vec2::new(half_width, half_height),
-        Color::WHITE,
+        css::WHITE,
     );
     // Bottom
     gizmos.line_2d(
         position + Vec2::new(-half_width, half_height),
         position + Vec2::new(half_width, half_height),
-        Color::WHITE,
+        css::WHITE,
     );
 
     // TODO: When bevy_gizmos get text, I'd *much rather* just show the Z value with text.
@@ -261,50 +261,49 @@ fn draw_bounding_box(gizmos: &mut Gizmos, z_fn: &ZFunction, position: Vec2, size
     //     position,
     //     0.0,
     //     size,
-    //     Color::WHITE,
+    //     css::WHITE,
     // );
     // ```
-    const Z_COLOR: Srgba = Srgba::GREEN;
     match z_fn {
         ZFunction::TransformX => gizmos.line_2d(
             position + Vec2::new(0.0, -half_height),
             position + Vec2::new(0.0, half_height),
-            Z_COLOR,
+            css::GREEN,
         ),
         ZFunction::TransformY => gizmos.line_2d(
             position + Vec2::new(-half_width, 0.0),
             position + Vec2::new(half_width, 0.0),
-            Z_COLOR,
+            css::GREEN,
         ),
         ZFunction::TransformXOffset(offset) => gizmos.line_2d(
             position + Vec2::new(*offset, -half_height),
             position + Vec2::new(*offset, half_height),
-            Z_COLOR,
+            css::GREEN,
         ),
         ZFunction::TransformYOffset(offset) => gizmos.line_2d(
             position + Vec2::new(-half_width, *offset),
             position + Vec2::new(half_width, *offset),
-            Z_COLOR,
+            css::GREEN,
         ),
         ZFunction::BbTop | ZFunction::BbTopInverse => gizmos.line_2d(
             position + Vec2::new(-half_width, half_height),
             position + Vec2::new(half_width, half_height),
-            Z_COLOR,
+            css::GREEN,
         ),
         ZFunction::BbBottom | ZFunction::BbBottomInverse => gizmos.line_2d(
             position + Vec2::new(-half_width, -half_height),
             position + Vec2::new(half_width, -half_height),
-            Z_COLOR,
+            css::GREEN,
         ),
         ZFunction::BbLeft | ZFunction::BbLeftInverse => gizmos.line_2d(
             position + Vec2::new(-half_width, -half_height),
             position + Vec2::new(-half_width, half_height),
-            Z_COLOR,
+            css::GREEN,
         ),
         ZFunction::BbRight | ZFunction::BbRightInverse => gizmos.line_2d(
             position + Vec2::new(half_width, -half_height),
             position + Vec2::new(half_width, half_height),
-            Z_COLOR,
+            css::GREEN,
         ),
         ZFunction::TransformZ
         | ZFunction::TransformZOffset(_)

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,8 +1,9 @@
 //! Logic for rendering debug visualizations
-use crate::text::VelloTextAlignment;
-use crate::{CoordinateSpace, VelloAsset, VelloAssetAlignment, VelloFont, VelloText, ZFunction};
-use bevy::math::Vec3Swizzles;
-use bevy::prelude::*;
+use crate::{
+    text::VelloTextAlignment, CoordinateSpace, VelloAsset, VelloAssetAlignment, VelloFont,
+    VelloText, ZFunction,
+};
+use bevy::{math::Vec3Swizzles, prelude::*};
 
 const RED_X_SIZE: f32 = 8.0;
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -212,12 +212,12 @@ fn draw_origin(gizmos: &mut Gizmos, projection: &OrthographicProjection, origin:
     let from = origin + RED_X_SIZE * Vec2::splat(1.0) * projection.scale;
     let to = origin + RED_X_SIZE * Vec2::splat(-1.0) * projection.scale;
 
-    gizmos.line_2d(from, to, Color::RED);
+    gizmos.line_2d(from, to, Srgba::RED);
 
     let from = origin + RED_X_SIZE * Vec2::new(1.0, -1.0) * projection.scale;
     let to = origin + RED_X_SIZE * Vec2::new(-1.0, 1.0) * projection.scale;
 
-    gizmos.line_2d(from, to, Color::RED);
+    gizmos.line_2d(from, to, Srgba::RED);
 }
 
 /// A helper method to draw the bounding box
@@ -263,7 +263,7 @@ fn draw_bounding_box(gizmos: &mut Gizmos, z_fn: &ZFunction, position: Vec2, size
     //     Color::WHITE,
     // );
     // ```
-    const Z_COLOR: Color = Color::GREEN;
+    const Z_COLOR: Srgba = Srgba::GREEN;
     match z_fn {
         ZFunction::TransformX => gizmos.line_2d(
             position + Vec2::new(0.0, -half_height),

--- a/src/integrations/asset.rs
+++ b/src/integrations/asset.rs
@@ -1,6 +1,5 @@
 use crate::VectorFile;
-use bevy::prelude::*;
-use bevy::reflect::TypePath;
+use bevy::{prelude::*, reflect::TypePath};
 
 #[derive(Asset, TypePath, Clone)]
 pub struct VelloAsset {

--- a/src/integrations/dot_lottie/lottie_player.rs
+++ b/src/integrations/dot_lottie/lottie_player.rs
@@ -1,6 +1,5 @@
 use super::PlayerState;
-use bevy::prelude::*;
-use bevy::utils::hashbrown::HashMap;
+use bevy::{prelude::*, utils::hashbrown::HashMap};
 
 /// A lottie player that closely mirrors the behavior and functionality for
 /// dotLottie Interactivity.

--- a/src/integrations/dot_lottie/systems.rs
+++ b/src/integrations/dot_lottie/systems.rs
@@ -1,11 +1,9 @@
 use super::DotLottiePlayer;
-use crate::integrations::lottie::PlaybackPlayMode;
 use crate::{
-    PlaybackDirection, PlaybackLoopBehavior, PlaybackOptions, PlayerTransition, Playhead,
-    VectorFile, VelloAsset,
+    integrations::lottie::PlaybackPlayMode, PlaybackDirection, PlaybackLoopBehavior,
+    PlaybackOptions, PlayerTransition, Playhead, VectorFile, VelloAsset,
 };
-use bevy::prelude::*;
-use bevy::utils::Instant;
+use bevy::{prelude::*, utils::Instant};
 use std::time::Duration;
 use vello_svg::usvg::strict_num::Ulps;
 

--- a/src/integrations/dot_lottie/systems.rs
+++ b/src/integrations/dot_lottie/systems.rs
@@ -204,6 +204,8 @@ pub fn run_transitions(
                     }
                 }
                 PlayerTransition::OnComplete { state } => {
+                    // can be irrefutable if only feature is lottie
+                    #[allow(irrefutable_let_patterns)]
                     if let VectorFile::Lottie(composition) = &current_asset.file {
                         let loops_needed = match options.looping {
                             PlaybackLoopBehavior::DoNotLoop => Some(0),

--- a/src/integrations/error.rs
+++ b/src/integrations/error.rs
@@ -1,6 +1,7 @@
-use bevy::utils::thiserror::{self, Error};
+use thiserror::{self, Error};
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum VectorLoaderError {
     #[error("Could not load file: {0}")]
     Io(#[from] std::io::Error),
@@ -8,8 +9,8 @@ pub enum VectorLoaderError {
     FromStrUtf8(#[from] std::str::Utf8Error),
     #[cfg(feature = "svg")]
     #[error("Could not parse svg: {0}")]
-    Usvg(#[from] vello_svg::usvg::Error),
+    VelloSvg(#[from] vello_svg::Error),
     #[cfg(feature = "lottie")]
     #[error("Could not parse lottie: {0}")]
-    Velato(#[from] velato::VelatoError),
+    Velato(#[from] velato::Error),
 }

--- a/src/integrations/lottie/asset_loader.rs
+++ b/src/integrations/lottie/asset_loader.rs
@@ -4,7 +4,7 @@ use crate::VelloAsset;
 use bevy::asset::io::Reader;
 use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
 use bevy::prelude::*;
-use bevy::utils::BoxedFuture;
+use bevy::utils::ConditionalSendFuture;
 
 #[derive(Default)]
 pub struct VelloLottieLoader;
@@ -21,7 +21,7 @@ impl AssetLoader for VelloLottieLoader {
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+    ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/src/integrations/lottie/asset_loader.rs
+++ b/src/integrations/lottie/asset_loader.rs
@@ -1,10 +1,12 @@
-use crate::integrations::lottie::load_lottie_from_bytes;
-use crate::integrations::VectorLoaderError;
-use crate::VelloAsset;
-use bevy::asset::io::Reader;
-use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
-use bevy::prelude::*;
-use bevy::utils::ConditionalSendFuture;
+use crate::{
+    integrations::{lottie::load_lottie_from_bytes, VectorLoaderError},
+    VelloAsset,
+};
+use bevy::{
+    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
+    prelude::*,
+    utils::ConditionalSendFuture,
+};
 
 #[derive(Default)]
 pub struct VelloLottieLoader;

--- a/src/integrations/lottie/parse.rs
+++ b/src/integrations/lottie/parse.rs
@@ -1,5 +1,4 @@
-use crate::integrations::VectorLoaderError;
-use crate::{VectorFile, VelloAsset};
+use crate::{integrations::VectorLoaderError, VectorFile, VelloAsset};
 use bevy::prelude::*;
 use std::sync::Arc;
 

--- a/src/integrations/lottie/playback_options.rs
+++ b/src/integrations/lottie/playback_options.rs
@@ -1,8 +1,7 @@
 //! Playback options for lottie files.
 
 use bevy::prelude::*;
-use std::ops::Range;
-use std::time::Duration;
+use std::{ops::Range, time::Duration};
 
 /// Playback options which adjust the playback of an asset.
 ///

--- a/src/integrations/lottie/playhead.rs
+++ b/src/integrations/lottie/playhead.rs
@@ -1,7 +1,7 @@
-use bevy::prelude::*;
-use bevy::utils::Instant;
+use bevy::{prelude::*, utils::Instant};
 
-/// The playhead for a vello asset. This cannot be constructed by the user, it is created automatically and available on the first frame.
+/// The playhead for a vello asset. This cannot be constructed by the user, it is created
+/// automatically and available on the first frame.
 #[derive(PartialEq, Component, Clone, Debug)]
 pub struct Playhead {
     /// Used to track transitions relating to time.

--- a/src/integrations/lottie/systems.rs
+++ b/src/integrations/lottie/systems.rs
@@ -1,9 +1,8 @@
-use crate::integrations::lottie::PlaybackPlayMode;
 use crate::{
-    PlaybackDirection, PlaybackLoopBehavior, PlaybackOptions, Playhead, VectorFile, VelloAsset,
+    integrations::lottie::PlaybackPlayMode, PlaybackDirection, PlaybackLoopBehavior,
+    PlaybackOptions, Playhead, VectorFile, VelloAsset,
 };
-use bevy::prelude::*;
-use bevy::utils::Instant;
+use bevy::{prelude::*, utils::Instant};
 use std::time::Duration;
 use vello_svg::usvg::strict_num::Ulps;
 

--- a/src/integrations/lottie/theme.rs
+++ b/src/integrations/lottie/theme.rs
@@ -1,11 +1,13 @@
 //! A component to augment playback colors.
 //!
-//! A long-term vision here is a selector-styled language, but now is just color swapping by layer name.
+//! A long-term vision here is a selector-styled language, but now is just color swapping by layer
+//! name.
 
-use bevy::prelude::*;
-use bevy::utils::HashMap;
-use velato::model::{Brush, Shape};
-use velato::Composition;
+use bevy::{prelude::*, utils::HashMap};
+use velato::{
+    model::{Brush, Shape},
+    Composition,
+};
 
 #[derive(PartialEq, Component, Default, Clone, Debug, Reflect)]
 #[reflect(Component)]

--- a/src/integrations/lottie/theme.rs
+++ b/src/integrations/lottie/theme.rs
@@ -62,11 +62,14 @@ impl Theme {
                     continue 'layers;
                 }
             };
+            // TODO: Vello hasn't fully implemented color spaces yet, so I'm very unsure of
+            // which color space to use here.
+            let target_color = target_color.to_linear();
             let target_color = vello::peniko::Color::rgba(
-                target_color.r().into(),
-                target_color.g().into(),
-                target_color.b().into(),
-                target_color.a().into(),
+                target_color.red as _,
+                target_color.green as _,
+                target_color.blue as _,
+                target_color.alpha as _,
             );
             for shape in shapes.iter_mut() {
                 recolor_shape(shape, target_color);

--- a/src/integrations/svg/asset_loader.rs
+++ b/src/integrations/svg/asset_loader.rs
@@ -1,10 +1,12 @@
-use crate::integrations::svg::load_svg_from_bytes;
-use crate::integrations::VectorLoaderError;
-use crate::VelloAsset;
-use bevy::asset::io::Reader;
-use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
-use bevy::prelude::*;
-use bevy::utils::ConditionalSendFuture;
+use crate::{
+    integrations::{svg::load_svg_from_bytes, VectorLoaderError},
+    VelloAsset,
+};
+use bevy::{
+    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
+    prelude::*,
+    utils::ConditionalSendFuture,
+};
 
 #[derive(Default)]
 pub struct VelloSvgLoader;

--- a/src/integrations/svg/asset_loader.rs
+++ b/src/integrations/svg/asset_loader.rs
@@ -4,7 +4,7 @@ use crate::VelloAsset;
 use bevy::asset::io::Reader;
 use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
 use bevy::prelude::*;
-use bevy::utils::BoxedFuture;
+use bevy::utils::ConditionalSendFuture;
 
 #[derive(Default)]
 pub struct VelloSvgLoader;
@@ -21,7 +21,7 @@ impl AssetLoader for VelloSvgLoader {
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+    ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/src/integrations/svg/parse.rs
+++ b/src/integrations/svg/parse.rs
@@ -1,23 +1,21 @@
 use crate::{integrations::VectorLoaderError, VectorFile, VelloAsset};
 use bevy::transform::components::Transform;
-use once_cell::sync::Lazy;
 use std::sync::Arc;
-use vello_svg::usvg::{self, fontdb::Database};
-
-pub static FONT_DB: Lazy<Database> = Lazy::new(usvg::fontdb::Database::default);
+use vello_svg::usvg::{self};
 
 /// Deserialize an SVG file from bytes.
 pub fn load_svg_from_bytes(bytes: &[u8]) -> Result<VelloAsset, VectorLoaderError> {
     let svg_str = std::str::from_utf8(bytes)?;
 
-    let usvg = usvg::Tree::from_str(svg_str, &usvg::Options::default(), &FONT_DB)?;
+    // Parse SVG
+    let tree =
+        usvg::Tree::from_str(svg_str, &usvg::Options::default()).map_err(vello_svg::Error::Svg)?;
 
     // Process the loaded SVG into Vello-compatible data
-    let mut scene = vello::Scene::new();
-    vello_svg::render_tree(&mut scene, &usvg);
+    let scene = vello_svg::render_tree(&tree);
 
-    let width = usvg.size().width();
-    let height = usvg.size().height();
+    let width = tree.size().width();
+    let height = tree.size().height();
 
     let vello_vector = VelloAsset {
         file: VectorFile::Svg(Arc::new(scene)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,16 +14,18 @@ pub mod render;
 pub mod text;
 
 // Re-exports
-pub use {velato, vello, vello_svg};
+pub use velato;
+pub use vello;
+pub use vello_svg;
 
 pub mod prelude {
-    pub use {vello, vello::kurbo, vello::peniko, vello::skrifa};
+    pub use vello::{self, kurbo, peniko, skrifa};
 
-    pub use crate::debug::DebugVisualizations;
-    pub use crate::integrations::{VectorFile, VelloAsset, VelloAssetAlignment};
-    pub use crate::render::{VelloCanvasMaterial, ZFunction};
-    pub use crate::text::{VelloFont, VelloText, VelloTextAlignment};
     pub use crate::{
+        debug::DebugVisualizations,
+        integrations::{VectorFile, VelloAsset, VelloAssetAlignment},
+        render::{VelloCanvasMaterial, ZFunction},
+        text::{VelloFont, VelloText, VelloTextAlignment},
         CoordinateSpace, VelloAssetBundle, VelloScene, VelloSceneBundle, VelloTextBundle,
     };
 
@@ -57,7 +59,9 @@ pub struct VelloAssetBundle {
     pub transform: Transform,
     /// The global transform managed by Bevy
     pub global_transform: GlobalTransform,
-    /// Use a depth-sorting function for this asset, used when rendering. By default, all assets use the transform's Z-coordinate for depth sorting in the renderer's painter's algorithm (see [`ZFunction::Inherited`]).
+    /// Use a depth-sorting function for this asset, used when rendering. By default, all assets
+    /// use the transform's Z-coordinate for depth sorting in the renderer's painter's algorithm
+    /// (see [`ZFunction::Inherited`]).
     pub z_function: ZFunction,
     /// Whether to render debug visualizations
     pub debug_visualizations: DebugVisualizations,
@@ -65,7 +69,8 @@ pub struct VelloAssetBundle {
     pub visibility: Visibility,
     /// Whether or not an entity is visible in the hierarchy.
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible. Should be extracted for rendering.
+    /// Algorithmically-computed indication of whether an entity is visible. Should be extracted
+    /// for rendering.
     pub view_visibility: ViewVisibility,
 }
 
@@ -83,7 +88,8 @@ pub struct VelloSceneBundle {
     pub visibility: Visibility,
     /// Whether or not an entity is visible in the hierarchy.
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible. Should be extracted for rendering.
+    /// Algorithmically-computed indication of whether an entity is visible. Should be extracted
+    /// for rendering.
     pub view_visibility: ViewVisibility,
 }
 
@@ -107,7 +113,8 @@ pub struct VelloTextBundle {
     pub visibility: Visibility,
     /// Whether or not an entity is visible in the hierarchy.
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible. Should be extracted for rendering.
+    /// Algorithmically-computed indication of whether an entity is visible. Should be extracted
+    /// for rendering.
     pub view_visibility: ViewVisibility,
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,7 +1,7 @@
-use crate::debug::DebugVisualizationsPlugin;
-use crate::render::VelloRenderPlugin;
-use crate::text::VelloFontLoader;
-use crate::{VelloAsset, VelloFont};
+use crate::{
+    debug::DebugVisualizationsPlugin, render::VelloRenderPlugin, text::VelloFontLoader, VelloAsset,
+    VelloFont,
+};
 use bevy::prelude::*;
 
 pub struct VelloPlugin;

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -159,11 +159,6 @@ pub fn scene_instances(
     for (scene, coord_space, transform, view_visibility, inherited_visibility, ui_node) in
         query_scenes.iter()
     {
-        error!(
-            "view: {}, inherited: {}",
-            view_visibility.get(),
-            inherited_visibility.get()
-        );
         if view_visibility.get() && inherited_visibility.get() {
             commands.spawn(ExtractedRenderScene {
                 transform: *transform,

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -17,12 +17,11 @@ pub struct ExtractedRenderAsset {
     pub z_function: ZFunction,
     pub render_mode: CoordinateSpace,
     pub ui_node: Option<Node>,
+    pub alpha: f32,
     #[cfg(feature = "lottie")]
     pub theme: Option<crate::Theme>,
     #[cfg(feature = "lottie")]
     pub playhead: f64,
-    #[cfg(feature = "lottie")]
-    pub alpha: f32,
 }
 
 #[cfg(feature = "svg")]
@@ -56,7 +55,6 @@ pub fn extract_svg_instances(
         if let Some(
             asset @ VelloAsset {
                 file: _file @ crate::VectorFile::Svg(_),
-                #[cfg(feature = "lottie")]
                 alpha,
                 ..
             },
@@ -70,12 +68,11 @@ pub fn extract_svg_instances(
                     z_function: *z_function,
                     render_mode: *coord_space,
                     ui_node: ui_node.cloned(),
+                    alpha: *alpha,
                     #[cfg(feature = "lottie")]
                     theme: None,
                     #[cfg(feature = "lottie")]
                     playhead: 0.0,
-                    #[cfg(feature = "lottie")]
-                    alpha: *alpha,
                 });
             }
         }

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -15,12 +15,14 @@ pub struct ExtractedRenderAsset {
     pub alignment: VelloAssetAlignment,
     pub transform: GlobalTransform,
     pub z_function: ZFunction,
+    pub render_mode: CoordinateSpace,
+    pub ui_node: Option<Node>,
     #[cfg(feature = "lottie")]
     pub theme: Option<crate::Theme>,
-    pub render_mode: CoordinateSpace,
+    #[cfg(feature = "lottie")]
     pub playhead: f64,
+    #[cfg(feature = "lottie")]
     pub alpha: f32,
-    pub ui_node: Option<Node>,
 }
 
 #[cfg(feature = "svg")]
@@ -54,6 +56,7 @@ pub fn extract_svg_instances(
         if let Some(
             asset @ VelloAsset {
                 file: _file @ crate::VectorFile::Svg(_),
+                #[cfg(feature = "lottie")]
                 alpha,
                 ..
             },
@@ -65,12 +68,14 @@ pub fn extract_svg_instances(
                     transform: *transform,
                     alignment: *alignment,
                     z_function: *z_function,
+                    render_mode: *coord_space,
+                    ui_node: ui_node.cloned(),
                     #[cfg(feature = "lottie")]
                     theme: None,
-                    render_mode: *coord_space,
+                    #[cfg(feature = "lottie")]
                     playhead: 0.0,
+                    #[cfg(feature = "lottie")]
                     alpha: *alpha,
-                    ui_node: ui_node.cloned(),
                 });
             }
         }

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -155,6 +155,11 @@ pub fn scene_instances(
     for (scene, coord_space, transform, view_visibility, inherited_visibility, ui_node) in
         query_scenes.iter()
     {
+        error!(
+            "view: {}, inherited: {}",
+            view_visibility.get(),
+            inherited_visibility.get()
+        );
         if view_visibility.get() && inherited_visibility.get() {
             commands.spawn(ExtractedRenderScene {
                 transform: *transform,

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,9 +1,13 @@
 use super::z_function::ZFunction;
-use crate::text::VelloTextAlignment;
-use crate::{CoordinateSpace, VelloAsset, VelloAssetAlignment, VelloFont, VelloScene, VelloText};
-use bevy::prelude::*;
-use bevy::render::{extract_component::ExtractComponent, Extract};
-use bevy::window::PrimaryWindow;
+use crate::{
+    text::VelloTextAlignment, CoordinateSpace, VelloAsset, VelloAssetAlignment, VelloFont,
+    VelloScene, VelloText,
+};
+use bevy::{
+    prelude::*,
+    render::{extract_component::ExtractComponent, Extract},
+    window::PrimaryWindow,
+};
 
 #[derive(Component, Clone)]
 pub struct ExtractedRenderAsset {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,7 +1,7 @@
 //! Components and logic for rendering.
 
 use bevy::prelude::*;
-use bevy::render::mesh::MeshVertexBufferLayout;
+use bevy::render::mesh::MeshVertexBufferLayoutRef;
 use bevy::render::render_resource::{
     AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
     VertexBufferLayout, VertexFormat, VertexStepMode,
@@ -39,7 +39,7 @@ impl Material2d for VelloCanvasMaterial {
 
     fn specialize(
         descriptor: &mut RenderPipelineDescriptor,
-        _layout: &MeshVertexBufferLayout,
+        _layout: &MeshVertexBufferLayoutRef,
         _key: Material2dKey<Self>,
     ) -> Result<(), SpecializedMeshPipelineError> {
         let formats = vec![

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,12 +1,16 @@
 //! Components and logic for rendering.
 
-use bevy::prelude::*;
-use bevy::render::mesh::MeshVertexBufferLayoutRef;
-use bevy::render::render_resource::{
-    AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
-    VertexBufferLayout, VertexFormat, VertexStepMode,
+use bevy::{
+    prelude::*,
+    render::{
+        mesh::MeshVertexBufferLayoutRef,
+        render_resource::{
+            AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
+            VertexBufferLayout, VertexFormat, VertexStepMode,
+        },
+    },
+    sprite::{Material2d, Material2dKey},
 };
-use bevy::sprite::{Material2d, Material2dKey};
 
 mod extract;
 mod plugin;

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -22,7 +22,7 @@ impl Plugin for VelloRenderPlugin {
             Shader::from_wgsl
         );
 
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
 

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -1,15 +1,23 @@
-use super::extract::{self, ExtractedPixelScale, SSRenderTarget};
-use super::{prepare, systems};
-use crate::render::extract::ExtractedRenderText;
-use crate::render::SSRT_SHADER_HANDLE;
-use crate::{VelloCanvasMaterial, VelloFont};
-use bevy::asset::load_internal_asset;
-use bevy::prelude::*;
-use bevy::render::extract_component::ExtractComponentPlugin;
-use bevy::render::render_asset::RenderAssetPlugin;
-use bevy::render::renderer::RenderDevice;
-use bevy::render::{Render, RenderApp, RenderSet};
-use bevy::sprite::Material2dPlugin;
+use super::{
+    extract::{self, ExtractedPixelScale, SSRenderTarget},
+    prepare, systems,
+};
+use crate::{
+    render::{extract::ExtractedRenderText, SSRT_SHADER_HANDLE},
+    VelloAsset, VelloCanvasMaterial, VelloFont, VelloScene,
+};
+use bevy::{
+    asset::load_internal_asset,
+    prelude::*,
+    render::{
+        extract_component::ExtractComponentPlugin,
+        render_asset::RenderAssetPlugin,
+        renderer::RenderDevice,
+        view::{check_visibility, VisibilitySystems},
+        Render, RenderApp, RenderSet,
+    },
+    sprite::Material2dPlugin,
+};
 
 pub struct VelloRenderPlugin;
 
@@ -68,6 +76,11 @@ impl Plugin for VelloRenderPlugin {
         .add_systems(
             Update,
             (systems::resize_rendertargets, systems::clear_when_empty),
+        )
+        .add_systems(
+            PostUpdate,
+            check_visibility::<Or<(With<VelloScene>, With<Handle<VelloAsset>>)>>
+                .in_set(VisibilitySystems::CheckVisibility),
         );
     }
 }

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -81,10 +81,10 @@ impl PrepareRenderInstance for ExtractedRenderAsset {
                 model_matrix.w_axis.y *= -1.0;
 
                 let (projection_mat, view_mat) = {
-                    let mut view_mat = view.transform.compute_matrix();
+                    let mut view_mat = view.world_from_view.compute_matrix();
                     view_mat.w_axis.y *= -1.0;
 
-                    (view.projection, view_mat)
+                    (view.clip_from_view, view_mat)
                 };
 
                 let view_proj_matrix = projection_mat * view_mat.inverse();
@@ -183,10 +183,10 @@ pub fn prepare_scene_affines(
                 model_matrix.w_axis.y *= -1.0;
 
                 let (projection_mat, view_mat) = {
-                    let mut view_mat = view.transform.compute_matrix();
+                    let mut view_mat = view.world_from_view.compute_matrix();
                     view_mat.w_axis.y *= -1.0;
 
-                    (view.projection, view_mat)
+                    (view.clip_from_view, view_mat)
                 };
 
                 let view_proj_matrix = projection_mat * view_mat.inverse();
@@ -241,10 +241,10 @@ pub fn prepare_text_affines(
         model_matrix.w_axis.y *= -1.0;
 
         let (projection_mat, view_mat) = {
-            let mut view_mat = view.transform.compute_matrix();
+            let mut view_mat = view.world_from_view.compute_matrix();
             view_mat.w_axis.y *= -1.0;
 
-            (view.projection, view_mat)
+            (view.clip_from_view, view_mat)
         };
 
         let view_proj_matrix = projection_mat * view_mat.inverse();

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -2,9 +2,10 @@ use super::extract::{
     ExtractedPixelScale, ExtractedRenderAsset, ExtractedRenderScene, ExtractedRenderText,
 };
 use crate::CoordinateSpace;
-use bevy::prelude::*;
-use bevy::render::camera::ExtractedCamera;
-use bevy::render::view::ExtractedView;
+use bevy::{
+    prelude::*,
+    render::{camera::ExtractedCamera, view::ExtractedView},
+};
 use vello::kurbo::Affine;
 
 #[derive(Component, Copy, Clone, Deref, DerefMut)]
@@ -16,7 +17,8 @@ pub struct PreparedTransform(GlobalTransform);
 #[derive(Component, Copy, Clone, Deref, DerefMut)]
 pub struct PreparedZIndex(f32);
 
-// All extracted bevy_vello render instance types should implement this (RenderAsset, RenderScene, RenderText, etc...)
+// All extracted bevy_vello render instance types should implement this (RenderAsset, RenderScene,
+// RenderText, etc...)
 pub trait PrepareRenderInstance {
     fn z_index(&self, transform: GlobalTransform) -> PreparedZIndex;
     fn final_transform(&self) -> PreparedTransform;

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -23,11 +23,7 @@ use bevy::{
     sprite::{MaterialMesh2dBundle, Mesh2dHandle},
     window::{WindowResized, WindowResolution},
 };
-use vello::{
-    kurbo::{Affine, Rect},
-    peniko::Mix,
-    AaSupport, RenderParams, Renderer, RendererOptions, Scene,
-};
+use vello::{kurbo::Affine, AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 
 pub fn setup_image(images: &mut Assets<Image>, window: &WindowResolution) -> Handle<Image> {
     let size = Extent3d {
@@ -134,6 +130,7 @@ pub fn render_scene(
     // scene to be rendered
     let mut scene_buffer = Scene::new();
     for (_, _, (affine, render_item)) in render_queue.iter_mut() {
+        #[allow(unused_variables)]
         match render_item {
             RenderItem::Asset(ExtractedRenderAsset {
                 asset,
@@ -148,10 +145,15 @@ pub fn render_scene(
                 crate::VectorFile::Svg(scene) => {
                     if *alpha < 1.0 {
                         scene_buffer.push_layer(
-                            Mix::Normal,
+                            vello::peniko::Mix::Normal,
                             *alpha,
                             *affine,
-                            &Rect::new(0.0, 0.0, asset.width as f64, asset.height as f64),
+                            &vello::kurbo::Rect::new(
+                                0.0,
+                                0.0,
+                                asset.width as f64,
+                                asset.height as f64,
+                            ),
                         );
                     }
                     scene_buffer.append(scene, Some(*affine));
@@ -163,10 +165,15 @@ pub fn render_scene(
                 crate::VectorFile::Lottie(composition) => {
                     if *alpha < 1.0 {
                         scene_buffer.push_layer(
-                            Mix::Normal,
+                            vello::peniko::Mix::Normal,
                             *alpha,
                             *affine,
-                            &Rect::new(0.0, 0.0, asset.width as f64, asset.height as f64),
+                            &vello::kurbo::Rect::new(
+                                0.0,
+                                0.0,
+                                asset.width as f64,
+                                asset.height as f64,
+                            ),
                         );
                     }
                     velato_renderer.append(

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -1,22 +1,29 @@
-use super::extract::{ExtractedRenderAsset, ExtractedRenderText, SSRenderTarget};
-use super::prepare::PreparedAffine;
-use super::VelloRenderer;
-use crate::render::extract::ExtractedRenderScene;
-use crate::render::prepare::PreparedZIndex;
-use crate::{CoordinateSpace, VelloCanvasMaterial, VelloFont};
-use bevy::prelude::*;
-use bevy::render::mesh::Indices;
-use bevy::render::render_asset::{RenderAssetUsages, RenderAssets};
-use bevy::render::render_resource::{
-    Extent3d, PrimitiveTopology, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
+use super::{
+    extract::{ExtractedRenderAsset, ExtractedRenderText, SSRenderTarget},
+    prepare::PreparedAffine,
+    VelloRenderer,
 };
-use bevy::render::renderer::{RenderDevice, RenderQueue};
-use bevy::render::texture::GpuImage;
-use bevy::render::view::NoFrustumCulling;
-use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
-use bevy::window::{WindowResized, WindowResolution};
-use vello::kurbo::Affine;
-use vello::{AaSupport, RenderParams, Renderer, RendererOptions, Scene};
+use crate::{
+    render::{extract::ExtractedRenderScene, prepare::PreparedZIndex},
+    CoordinateSpace, VelloCanvasMaterial, VelloFont,
+};
+use bevy::{
+    prelude::*,
+    render::{
+        mesh::Indices,
+        render_asset::{RenderAssetUsages, RenderAssets},
+        render_resource::{
+            Extent3d, PrimitiveTopology, TextureDescriptor, TextureDimension, TextureFormat,
+            TextureUsages,
+        },
+        renderer::{RenderDevice, RenderQueue},
+        texture::GpuImage,
+        view::NoFrustumCulling,
+    },
+    sprite::{MaterialMesh2dBundle, Mesh2dHandle},
+    window::{WindowResized, WindowResolution},
+};
+use vello::{kurbo::Affine, AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 
 pub fn setup_image(images: &mut Assets<Image>, window: &WindowResolution) -> Handle<Image> {
     let size = Extent3d {
@@ -292,7 +299,9 @@ pub fn setup_ss_rendertarget(
         .spawn(MaterialMesh2dBundle {
             mesh,
             material,
-            transform: Transform::from_translation(0.001 * Vec3::NEG_Z), // Make sure the vello canvas renders behind Gizmos
+            transform: Transform::from_translation(0.001 * Vec3::NEG_Z), /* Make sure the vello
+                                                                          * canvas renders behind
+                                                                          * Gizmos */
             ..Default::default()
         })
         .insert(NoFrustumCulling)

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -11,6 +11,7 @@ use bevy::render::render_resource::{
     Extent3d, PrimitiveTopology, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
 use bevy::render::renderer::{RenderDevice, RenderQueue};
+use bevy::render::texture::GpuImage;
 use bevy::render::view::NoFrustumCulling;
 use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
 use bevy::window::{WindowResized, WindowResolution};
@@ -55,7 +56,7 @@ pub fn render_scene(
     query_render_scenes: Query<(&PreparedAffine, &ExtractedRenderScene)>,
     query_render_texts: Query<(&PreparedAffine, &ExtractedRenderText)>,
     mut font_render_assets: ResMut<RenderAssets<VelloFont>>,
-    gpu_images: Res<RenderAssets<Image>>,
+    gpu_images: Res<RenderAssets<GpuImage>>,
     device: Res<RenderDevice>,
     queue: Res<RenderQueue>,
     mut vello_renderer: Local<Option<VelloRenderer>>,
@@ -77,135 +78,136 @@ pub fn render_scene(
         )
     });
 
-    if let Ok(SSRenderTarget(render_target_image)) = ss_render_target.get_single() {
-        let gpu_image = gpu_images.get(render_target_image).unwrap();
+    let Ok(SSRenderTarget(render_target_image)) = ss_render_target.get_single() else {
+        error!("No render target");
+        return;
+    };
+    let gpu_image = gpu_images.get(render_target_image).unwrap();
 
-        enum RenderItem<'a> {
-            Asset(&'a ExtractedRenderAsset),
-            Scene(&'a ExtractedRenderScene),
-            Text(&'a ExtractedRenderText),
-        }
-        let mut render_queue: Vec<(f32, CoordinateSpace, (Affine, RenderItem))> =
-            query_render_vectors
-                .iter()
-                .map(|(&a, &b, c)| (*b, c.render_mode, (*a, RenderItem::Asset(c))))
-                .collect();
-        render_queue.extend(query_render_scenes.iter().map(|(&a, b)| {
-            (
-                b.transform.translation().z,
-                b.render_mode,
-                (*a, RenderItem::Scene(b)),
-            )
-        }));
-        render_queue.extend(query_render_texts.iter().map(|(&a, b)| {
-            (
-                b.transform.translation().z,
-                b.render_mode,
-                (*a, RenderItem::Text(b)),
-            )
-        }));
+    enum RenderItem<'a> {
+        Asset(&'a ExtractedRenderAsset),
+        Scene(&'a ExtractedRenderScene),
+        Text(&'a ExtractedRenderText),
+    }
+    let mut render_queue: Vec<(f32, CoordinateSpace, (Affine, RenderItem))> = query_render_vectors
+        .iter()
+        .map(|(&a, &b, c)| (*b, c.render_mode, (*a, RenderItem::Asset(c))))
+        .collect();
+    render_queue.extend(query_render_scenes.iter().map(|(&a, b)| {
+        (
+            b.transform.translation().z,
+            b.render_mode,
+            (*a, RenderItem::Scene(b)),
+        )
+    }));
+    render_queue.extend(query_render_texts.iter().map(|(&a, b)| {
+        (
+            b.transform.translation().z,
+            b.render_mode,
+            (*a, RenderItem::Text(b)),
+        )
+    }));
 
-        // Sort by render mode with screen space on top, then by z-index
-        render_queue.sort_by(
-            |(a_z_index, a_render_mode, _), (b_z_index, b_render_mode, _)| {
-                let z_index = a_z_index
-                    .partial_cmp(b_z_index)
-                    .unwrap_or(std::cmp::Ordering::Equal);
-                let render_mode = a_render_mode.cmp(b_render_mode);
-                render_mode.then(z_index)
-            },
-        );
+    // Sort by render mode with screen space on top, then by z-index
+    render_queue.sort_by(
+        |(a_z_index, a_render_mode, _), (b_z_index, b_render_mode, _)| {
+            let z_index = a_z_index
+                .partial_cmp(b_z_index)
+                .unwrap_or(std::cmp::Ordering::Equal);
+            let render_mode = a_render_mode.cmp(b_render_mode);
+            render_mode.then(z_index)
+        },
+    );
 
-        // Apply transforms to the respective fragments and add them to the
-        // scene to be rendered
-        let mut scene_buffer = Scene::new();
-        for (_, _, (affine, render_item)) in render_queue.iter_mut() {
-            match render_item {
-                RenderItem::Asset(ExtractedRenderAsset {
-                    asset,
-                    #[cfg(feature = "lottie")]
-                    alpha,
-                    #[cfg(feature = "lottie")]
-                    theme,
-                    #[cfg(feature = "lottie")]
-                    playhead,
-                    ..
-                }) => match &asset.file {
-                    #[cfg(feature = "svg")]
-                    crate::VectorFile::Svg(scene) => {
-                        // TODO: Apply alpha
-                        scene_buffer.append(scene, Some(*affine));
-                    }
-                    #[cfg(feature = "lottie")]
-                    crate::VectorFile::Lottie(composition) => {
-                        velato_renderer.render(
-                            {
-                                theme
-                                    .as_ref()
-                                    .map(|cs| cs.recolor(composition))
-                                    .as_ref()
-                                    .unwrap_or(composition)
-                            },
-                            *playhead as f64,
-                            *affine,
-                            *alpha as f64,
-                            &mut scene_buffer,
-                        );
-                    }
-                    #[cfg(not(any(feature = "svg", feature = "lottie")))]
-                    _ => unimplemented!(),
-                },
-                RenderItem::Scene(ExtractedRenderScene { scene, .. }) => {
+    // Apply transforms to the respective fragments and add them to the
+    // scene to be rendered
+    let mut scene_buffer = Scene::new();
+    for (_, _, (affine, render_item)) in render_queue.iter_mut() {
+        match render_item {
+            RenderItem::Asset(ExtractedRenderAsset {
+                asset,
+                #[cfg(feature = "lottie")]
+                alpha,
+                #[cfg(feature = "lottie")]
+                theme,
+                #[cfg(feature = "lottie")]
+                playhead,
+                ..
+            }) => match &asset.file {
+                #[cfg(feature = "svg")]
+                crate::VectorFile::Svg(scene) => {
+                    // TODO: Apply alpha
                     scene_buffer.append(scene, Some(*affine));
                 }
-                RenderItem::Text(ExtractedRenderText {
-                    font,
-                    text,
-                    alignment,
-                    ..
-                }) => {
-                    if let Some(font) = font_render_assets.get_mut(font) {
-                        font.render(&mut scene_buffer, *affine, text, *alignment);
-                    }
+                #[cfg(feature = "lottie")]
+                crate::VectorFile::Lottie(composition) => {
+                    velato_renderer.append(
+                        {
+                            theme
+                                .as_ref()
+                                .map(|cs| cs.recolor(composition))
+                                .as_ref()
+                                .unwrap_or(composition)
+                        },
+                        *playhead as f64,
+                        *affine,
+                        *alpha as f64,
+                        &mut scene_buffer,
+                    );
+                }
+                #[cfg(not(any(feature = "svg", feature = "lottie")))]
+                _ => unimplemented!(),
+            },
+            RenderItem::Scene(ExtractedRenderScene { scene, .. }) => {
+                scene_buffer.append(scene, Some(*affine));
+            }
+            RenderItem::Text(ExtractedRenderText {
+                font,
+                text,
+                alignment,
+                ..
+            }) => {
+                if let Some(font) = font_render_assets.get_mut(font) {
+                    font.render(&mut scene_buffer, *affine, text, *alignment);
                 }
             }
         }
+    }
 
-        // TODO: Vello should be ignoring 0-sized buffers in the future, so this could go away.
-        // Prevent a panic in the vello renderer if all the items contain empty encoding data
-        let empty_encodings = render_queue
-            .iter()
-            .filter(|(_, _, (_, item))| match item {
-                RenderItem::Asset(a) => match &a.asset.file {
-                    #[cfg(feature = "svg")]
-                    crate::VectorFile::Svg(scene) => scene.encoding().is_empty(),
-                    #[cfg(feature = "lottie")]
-                    crate::VectorFile::Lottie(composition) => composition.layers.is_empty(),
-                    #[cfg(not(any(feature = "svg", feature = "lottie")))]
-                    _ => unimplemented!(),
+    // TODO: Vello should be ignoring 0-sized buffers in the future, so this could go away.
+    // Prevent a panic in the vello renderer if all the items contain empty encoding data
+    let empty_encodings = render_queue
+        .iter()
+        .filter(|(_, _, (_, item))| match item {
+            RenderItem::Asset(a) => match &a.asset.file {
+                #[cfg(feature = "svg")]
+                crate::VectorFile::Svg(scene) => scene.encoding().is_empty(),
+                #[cfg(feature = "lottie")]
+                crate::VectorFile::Lottie(composition) => composition.layers.is_empty(),
+                #[cfg(not(any(feature = "svg", feature = "lottie")))]
+                _ => unimplemented!(),
+            },
+            RenderItem::Scene(s) => s.scene.encoding().is_empty(),
+            RenderItem::Text(t) => t.text.content.is_empty(),
+        })
+        .count()
+        == render_queue.len();
+
+    if !render_queue.is_empty() && !empty_encodings {
+        renderer
+            .render_to_texture(
+                device.wgpu_device(),
+                &queue,
+                &scene_buffer,
+                &gpu_image.texture_view,
+                &RenderParams {
+                    base_color: vello::peniko::Color::TRANSPARENT,
+                    width: gpu_image.size.x as u32,
+                    height: gpu_image.size.y as u32,
+                    antialiasing_method: vello::AaConfig::Area,
                 },
-                RenderItem::Scene(s) => s.scene.encoding().is_empty(),
-                RenderItem::Text(t) => t.text.content.is_empty(),
-            })
-            .count()
-            == render_queue.len();
-
-        if !render_queue.is_empty() && !empty_encodings {
-            renderer
-                .render_to_texture(
-                    device.wgpu_device(),
-                    &queue,
-                    &scene_buffer,
-                    &gpu_image.texture_view,
-                    &RenderParams {
-                        base_color: vello::peniko::Color::TRANSPARENT,
-                        width: gpu_image.size.x as u32,
-                        height: gpu_image.size.y as u32,
-                        antialiasing_method: vello::AaConfig::Area,
-                    },
-                )
-                .unwrap();
-        }
+            )
+            .unwrap();
     }
 }
 

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -1,14 +1,15 @@
-use super::vello_text::VelloText;
-use super::VelloTextAlignment;
-use bevy::prelude::*;
-use bevy::reflect::TypePath;
-use bevy::render::render_asset::RenderAsset;
+use super::{vello_text::VelloText, VelloTextAlignment};
+use bevy::{prelude::*, reflect::TypePath, render::render_asset::RenderAsset};
 use std::sync::Arc;
-use vello::glyph::skrifa::{FontRef, MetadataProvider};
-use vello::glyph::Glyph;
-use vello::kurbo::Affine;
-use vello::peniko::{self, Blob, Brush, Color, Font};
-use vello::Scene;
+use vello::{
+    glyph::{
+        skrifa::{FontRef, MetadataProvider},
+        Glyph,
+    },
+    kurbo::Affine,
+    peniko::{self, Blob, Brush, Color, Font},
+    Scene,
+};
 
 const VARIATIONS: &[(&str, f32)] = &[];
 
@@ -42,7 +43,8 @@ impl VelloFont {
         let font_size = vello::skrifa::instance::Size::new(text.size);
         let charmap = font.charmap();
         let axes = font.axes();
-        // TODO: What do Variations here do? Any font nerds know? I'm definitely not doing this right.
+        // TODO: What do Variations here do? Any font nerds know? I'm definitely not doing this
+        // right.
         let var_loc = axes.location(VARIATIONS);
         let metrics = font.metrics(font_size, &var_loc);
         let line_height = metrics.ascent - metrics.descent + metrics.leading;

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -15,7 +15,7 @@ const VARIATIONS: &[(&str, f32)] = &[];
 
 #[derive(Asset, TypePath, Clone)]
 pub struct VelloFont {
-    pub font: Arc<peniko::Font>,
+    pub font: peniko::Font,
 }
 
 impl RenderAsset for VelloFont {
@@ -34,7 +34,7 @@ impl RenderAsset for VelloFont {
 impl VelloFont {
     pub fn new(font_data: Vec<u8>) -> Self {
         Self {
-            font: Arc::new(Font::new(Blob::new(Arc::new(font_data)), 0)),
+            font: Font::new(Blob::new(Arc::new(font_data)), 0),
         }
     }
 

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -18,19 +18,15 @@ pub struct VelloFont {
 }
 
 impl RenderAsset for VelloFont {
-    type PreparedAsset = VelloFont;
+    type SourceAsset = VelloFont;
 
     type Param = ();
 
-    fn asset_usage(&self) -> bevy::render::render_asset::RenderAssetUsages {
-        Default::default()
-    }
-
     fn prepare_asset(
-        self,
+        source_asset: Self::SourceAsset,
         _param: &mut bevy::ecs::system::SystemParamItem<Self::Param>,
-    ) -> Result<Self::PreparedAsset, bevy::render::render_asset::PrepareAssetError<Self>> {
-        Ok(self)
+    ) -> Result<Self, bevy::render::render_asset::PrepareAssetError<Self::SourceAsset>> {
+        Ok(source_asset)
     }
 }
 
@@ -46,11 +42,13 @@ impl VelloFont {
         let font_size = vello::skrifa::instance::Size::new(text.size);
         let charmap = font.charmap();
         let axes = font.axes();
+        // TODO: What do Variations here do? Any font nerds know? I'm definitely not doing this right.
         let var_loc = axes.location(VARIATIONS);
         let metrics = font.metrics(font_size, &var_loc);
         let line_height = metrics.ascent - metrics.descent + metrics.leading;
         let glyph_metrics = font.glyph_metrics(font_size, &var_loc);
 
+        // TODO: Parley recently implemented type hinting, I should be handling this.
         let mut pen_x = 0.0;
         let mut pen_y: f32 = 0.0;
         let mut width: f32 = 0.0;

--- a/src/text/font_loader.rs
+++ b/src/text/font_loader.rs
@@ -1,8 +1,9 @@
 use super::font::VelloFont;
 use crate::integrations::VectorLoaderError;
-use bevy::asset::io::Reader;
-use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
-use bevy::utils::ConditionalSendFuture;
+use bevy::{
+    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
+    utils::ConditionalSendFuture,
+};
 
 #[derive(Default)]
 pub struct VelloFontLoader;

--- a/src/text/font_loader.rs
+++ b/src/text/font_loader.rs
@@ -2,7 +2,7 @@ use super::font::VelloFont;
 use crate::integrations::VectorLoaderError;
 use bevy::asset::io::Reader;
 use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
-use bevy::utils::BoxedFuture;
+use bevy::utils::ConditionalSendFuture;
 
 #[derive(Default)]
 pub struct VelloFontLoader;
@@ -19,7 +19,7 @@ impl AssetLoader for VelloFontLoader {
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+    ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;


### PR DESCRIPTION
## 0.5.0

### Added

- New `scene_ui` example demonstrating a `VelloScene` attached to a `bevy::ui::Node`

### Changed

- Updated to bevy 0.14
- Updated to vello 0.2
- Updated to velato 0.3
- Updated to vello_svg 0.3

### Fixed

- Removed `Arc` in another `Arc` for `VelloFont`
- Opacity now correctly applies to SVG assets.
- Opacity now applies correctly to the lottie image group, rather than each element and path within it, causing overdraw.
- `VelloScene` components on `bevy::ui::Node` entities now account for Bevy's UI layout systems and render at the expected viewport coordinates

### Removed

- Pancam and/or egui from all examples besides the demo, as external dependencies can bottleneck upgrading to the next bevy version.