### PR TITLE
Do not wrap an `Arc` in another `Arc` in `VelloFont`

### DIFF
--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -14,7 +14,7 @@ const VARIATIONS: &[(&str, f32)] = &[];
 
 #[derive(Asset, TypePath, Clone)]
 pub struct VelloFont {
-    pub font: Arc<peniko::Font>,
+    pub font: peniko::Font,
 }
 
 impl RenderAsset for VelloFont {
@@ -37,7 +37,7 @@ impl RenderAsset for VelloFont {
 impl VelloFont {
     pub fn new(font_data: Vec<u8>) -> Self {
         Self {
-            font: Arc::new(Font::new(Blob::new(Arc::new(font_data)), 0)),
+            font: Font::new(Blob::new(Arc::new(font_data)), 0),
         }
     }
 


### PR DESCRIPTION
Closes #60.

There was a bit of confusion with what I originally meant in that issue, so I hope this small PR shows what I intended.