### PR TITLE
v0.5.1 - Release

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ run_wasm = "run --release --package run_wasm --"
 # Other crates use the alias run-wasm, even though crate names should use `_`s not `-`s
 # Allow this to be used
 run-wasm = "run_wasm"
+
+[target.'cfg(target_family = "wasm")']
+rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+## 0.5.1
+
+### Fixed
+
+- Updated to patch vello 0.2.1. It is now no-longer possible to panic when the vello encodings are empty.
+- The demo CI now deploys that bevy_pancam has been updated to bevy 0.14
+
 ## 0.5.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/linebender/bevy_vello"
 
@@ -50,7 +50,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bevy = { workspace = true }
-vello = "0.2.0"
+vello = "0.2.1"
 vello_svg = "0.3.0"
 velato = "0.3.0"
 thiserror = "1.0.61"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 [dependencies]
 bevy_vello = { path = "../../", features = ["experimental-dotLottie"] }
 bevy = { workspace = true }
-bevy_pancam = { version = "0.11", features = ["bevy_egui"] }
+bevy_pancam = { version = "0.12.0", features = ["bevy_egui"] }
 bevy_egui = "0.28.0"

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     .add_plugins(EguiPlugin)
     .add_plugins(VelloPlugin)
     .init_resource::<EmbeddedAssetRegistry>()
-    //.add_plugins(bevy_pancam::PanCamPlugin)
+    .add_plugins(bevy_pancam::PanCamPlugin)
     .add_systems(Startup, setup_vector_graphics)
     .add_systems(Update, (print_metadata, ui::controls_ui));
     embedded_asset!(app, "assets/calendar.json");
@@ -25,8 +25,7 @@ fn main() {
 }
 
 fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
-    //commands.spawn((Camera2dBundle::default(), bevy_pancam::PanCam::default()));
+    commands.spawn((Camera2dBundle::default(), bevy_pancam::PanCam::default()));
     commands
         .spawn(VelloAssetBundle {
             vector: asset_server.load::<VelloAsset>("embedded://demo/assets/calendar.json"),


### PR DESCRIPTION
## 0.5.1

### Fixed

- Updated to patch vello 0.2.1. It is now no-longer possible to panic when the vello encodings are empty.
- The demo CI now deploys that bevy_pancam has been updated to bevy 0.14