### PR TITLE
refactor: naming to be consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+### Changed
+
+- The field `VelloAssetBundle.vector` was renamed to `VelloAssetBundle.asset`.
+- Renamed `VelloAssetAlignment` to `VelloAssetAnchor`. Fields were renamed `alignment` were renamed to `asset_anchor`.
+- Renamed `VelloTextAlignment` to `VelloTextAnchor`. Fields were renamed `alignment` were renamed to `text_anchor`.
+
 ### Removed
 
 - Removed `ZFunction`s from the render pipeline. Now ordering is based solely on the `Transform`'s z component. If you dependeded on this behavior, you'll need to adjust the transform Z in a system prior to render.

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -28,7 +28,7 @@ fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServe
     commands.spawn((Camera2dBundle::default(), bevy_pancam::PanCam::default()));
     commands
         .spawn(VelloAssetBundle {
-            vector: asset_server.load::<VelloAsset>("embedded://demo/assets/calendar.json"),
+            asset: asset_server.load::<VelloAsset>("embedded://demo/assets/calendar.json"),
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0))
                 .with_scale(Vec3::splat(20.0)),
             debug_visualizations: DebugVisualizations::Visible,
@@ -78,6 +78,7 @@ fn print_metadata(
     for ev in asset_ev.read() {
         if let AssetEvent::LoadedWithDependencies { id } = ev {
             let asset = assets.get(*id).unwrap();
+            #[allow(irrefutable_let_patterns)]
             if let VectorFile::Lottie(composition) = &asset.file {
                 info!(
                     "Animated asset loaded. Layers:\n{:#?}",

--- a/examples/demo/src/ui.rs
+++ b/examples/demo/src/ui.rs
@@ -23,7 +23,9 @@ pub fn controls_ui(
     };
 
     let asset = assets.get(handle.id()).unwrap();
-    let VectorFile::Lottie(composition) = &asset.file else {
+    #[allow(irrefutable_let_patterns)]
+    let VectorFile::Lottie(composition) = &asset.file
+    else {
         return;
     };
 

--- a/examples/drag_n_drop/Cargo.toml
+++ b/examples/drag_n_drop/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy_vello = { path = "../../" }
+bevy_vello = { path = "../../", features = ["svg", "lottie"] }
 bevy = { workspace = true }

--- a/examples/drag_n_drop/src/main.rs
+++ b/examples/drag_n_drop/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(VelloAssetBundle {
-        vector: asset_server.load::<VelloAsset>("embedded://drag_n_drop/assets/fountain.svg"),
+        asset: asset_server.load::<VelloAsset>("embedded://drag_n_drop/assets/fountain.svg"),
         debug_visualizations: DebugVisualizations::Visible,
         transform: Transform::from_scale(Vec3::splat(5.0)),
         ..default()
@@ -34,7 +34,7 @@ fn drag_and_drop(
     asset_server: ResMut<AssetServer>,
     mut dnd_evr: EventReader<FileDragAndDrop>,
 ) {
-    let Ok(mut vector) = query.get_single_mut() else {
+    let Ok(mut asset) = query.get_single_mut() else {
         return;
     };
     for ev in dnd_evr.read() {
@@ -42,6 +42,6 @@ fn drag_and_drop(
             continue;
         };
         let new_handle = asset_server.load(path_buf.clone());
-        *vector = new_handle;
+        *asset = new_handle;
     }
 }

--- a/examples/lottie/src/main.rs
+++ b/examples/lottie/src/main.rs
@@ -21,7 +21,7 @@ fn load_lottie(mut commands: Commands, asset_server: ResMut<AssetServer>) {
 
     // Yes, it's this simple.
     commands.spawn(VelloAssetBundle {
-        vector: asset_server.load("embedded://lottie/assets/Tiger.json"),
+        asset: asset_server.load("embedded://lottie/assets/Tiger.json"),
         debug_visualizations: DebugVisualizations::Visible,
         transform: Transform::from_scale(Vec3::splat(0.5)),
         ..default()

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -21,7 +21,7 @@ fn load_svg(mut commands: Commands, asset_server: ResMut<AssetServer>) {
 
     // Yes, it's this simple.
     commands.spawn(VelloAssetBundle {
-        vector: asset_server.load("embedded://svg/assets/fountain.svg"),
+        asset: asset_server.load("embedded://svg/assets/fountain.svg"),
         debug_visualizations: DebugVisualizations::Visible,
         transform: Transform::from_scale(Vec3::splat(5.0)),
         ..default()

--- a/examples/text/src/main.rs
+++ b/examples/text/src/main.rs
@@ -2,7 +2,7 @@ use bevy::{
     asset::{embedded_asset, AssetMetaCheck},
     prelude::*,
 };
-use bevy_vello::{prelude::*, text::VelloTextAlignment, vello::peniko, VelloPlugin};
+use bevy_vello::{prelude::*, text::VelloTextAnchor, vello::peniko, VelloPlugin};
 
 fn main() {
     let mut app = App::new();
@@ -32,7 +32,7 @@ fn setup_worldspace_text(mut commands: Commands, asset_server: ResMut<AssetServe
             size: 50.0,
             brush: None,
         },
-        alignment: VelloTextAlignment::Center,
+        text_anchor: VelloTextAnchor::Center,
         transform: Transform::from_xyz(100.0, 100.0, 0.0),
         debug_visualizations: DebugVisualizations::Visible,
         ..default()
@@ -60,7 +60,7 @@ fn setup_screenspace_text(mut commands: Commands, asset_server: ResMut<AssetServ
             size: 15.0,
             brush: Some(peniko::Brush::Solid(peniko::Color::RED)),
         },
-        alignment: bevy_vello::text::VelloTextAlignment::TopLeft,
+        text_anchor: bevy_vello::text::VelloTextAnchor::TopLeft,
         transform: Transform::from_xyz(100.0, 85.0, 0.0),
         coordinate_space: CoordinateSpace::ScreenSpace,
         debug_visualizations: DebugVisualizations::Visible,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,7 +1,6 @@
 //! Logic for rendering debug visualizations
 use crate::{
-    text::VelloTextAlignment, CoordinateSpace, VelloAsset, VelloAssetAlignment, VelloFont,
-    VelloText,
+    text::VelloTextAnchor, CoordinateSpace, VelloAsset, VelloAssetAnchor, VelloFont, VelloText,
 };
 use bevy::{color::palettes::css, math::Vec3Swizzles, prelude::*};
 
@@ -28,14 +27,14 @@ fn render_asset_debug(
     query_vectors: Query<
         (
             &Handle<VelloAsset>,
-            &VelloAssetAlignment,
+            &VelloAssetAnchor,
             &GlobalTransform,
             &CoordinateSpace,
             &DebugVisualizations,
         ),
         Without<Node>,
     >,
-    vectors: Res<Assets<VelloAsset>>,
+    assets: Res<Assets<VelloAsset>>,
     query_cam: Query<(&Camera, &GlobalTransform, &OrthographicProjection), With<Camera2d>>,
     mut gizmos: Gizmos,
 ) {
@@ -44,20 +43,20 @@ fn render_asset_debug(
     };
 
     // Show vectors
-    for (vector, alignment, gtransform, space, _) in query_vectors
+    for (asset, asset_anchor, gtransform, space, _) in query_vectors
         .iter()
         .filter(|(_, _, _, _, d)| **d == DebugVisualizations::Visible)
     {
-        if let Some(vector) = vectors.get(vector) {
+        if let Some(asset) = assets.get(asset) {
             match space {
                 CoordinateSpace::WorldSpace => {
                     // Origin
                     let origin = gtransform.translation().xy();
                     draw_origin(&mut gizmos, projection, origin);
                     // Bounding box
-                    let gtransform = &alignment.compute(vector, gtransform);
+                    let gtransform = &asset_anchor.compute(asset, gtransform);
                     let rect_center = gtransform.translation().xy();
-                    let rect = vector.bb_in_world_space(gtransform);
+                    let rect = asset.bb_in_world_space(gtransform);
                     draw_bounding_box(&mut gizmos, rect_center, rect.size());
                 }
                 CoordinateSpace::ScreenSpace => {
@@ -68,12 +67,12 @@ fn render_asset_debug(
                     };
                     draw_origin(&mut gizmos, projection, origin);
                     // Bounding box
-                    let gtransform = &alignment.compute(vector, gtransform);
+                    let gtransform = &asset_anchor.compute(asset, gtransform);
                     let rect_center = gtransform.translation().xy();
                     let Some(rect_center) = camera.viewport_to_world_2d(view, rect_center) else {
                         continue;
                     };
-                    let Some(rect) = vector.bb_in_screen_space(gtransform, camera, view) else {
+                    let Some(rect) = asset.bb_in_screen_space(gtransform, camera, view) else {
                         continue;
                     };
                     draw_bounding_box(&mut gizmos, rect_center, rect.size());
@@ -89,7 +88,7 @@ fn render_text_debug(
         (
             &Handle<VelloFont>,
             &VelloText,
-            &VelloTextAlignment,
+            &VelloTextAnchor,
             &GlobalTransform,
             &CoordinateSpace,
             &DebugVisualizations,
@@ -105,7 +104,7 @@ fn render_text_debug(
     };
 
     // Show world-space vectors
-    for (font, text, alignment, gtransform, space, _) in query_world
+    for (font, text, text_anchor, gtransform, space, _) in query_world
         .iter()
         .filter(|(_, _, _, _, _, d)| **d == DebugVisualizations::Visible)
     {
@@ -117,33 +116,33 @@ fn render_text_debug(
                     draw_origin(&mut gizmos, projection, origin);
                     let size = rect.size();
                     let (width, height) = size.into();
-                    match alignment {
-                        VelloTextAlignment::BottomLeft => {}
-                        VelloTextAlignment::Bottom => {
+                    match text_anchor {
+                        VelloTextAnchor::BottomLeft => {}
+                        VelloTextAnchor::Bottom => {
                             origin.x += -width / 2.0;
                         }
-                        VelloTextAlignment::BottomRight => {
+                        VelloTextAnchor::BottomRight => {
                             origin.x += -width;
                         }
-                        VelloTextAlignment::TopLeft => {
+                        VelloTextAnchor::TopLeft => {
                             origin.y += -height;
                         }
-                        VelloTextAlignment::Left => {
+                        VelloTextAnchor::Left => {
                             origin.y += -height / 2.0;
                         }
-                        VelloTextAlignment::Top => {
+                        VelloTextAnchor::Top => {
                             origin.x += -width / 2.0;
                             origin.y += -height;
                         }
-                        VelloTextAlignment::Center => {
+                        VelloTextAnchor::Center => {
                             origin.x += -width / 2.0;
                             origin.y += -height / 2.0;
                         }
-                        VelloTextAlignment::TopRight => {
+                        VelloTextAnchor::TopRight => {
                             origin.x += -width;
                             origin.y += -height;
                         }
-                        VelloTextAlignment::Right => {
+                        VelloTextAnchor::Right => {
                             origin.x += -width;
                             origin.y += -height / 2.0;
                         }
@@ -163,33 +162,33 @@ fn render_text_debug(
                     draw_origin(&mut gizmos, projection, origin);
                     let size = rect.size();
                     let (width, height) = size.into();
-                    match alignment {
-                        VelloTextAlignment::BottomLeft => {}
-                        VelloTextAlignment::Bottom => {
+                    match text_anchor {
+                        VelloTextAnchor::BottomLeft => {}
+                        VelloTextAnchor::Bottom => {
                             origin.x += -width / 2.0;
                         }
-                        VelloTextAlignment::BottomRight => {
+                        VelloTextAnchor::BottomRight => {
                             origin.x += -width;
                         }
-                        VelloTextAlignment::TopLeft => {
+                        VelloTextAnchor::TopLeft => {
                             origin.y += height;
                         }
-                        VelloTextAlignment::Left => {
+                        VelloTextAnchor::Left => {
                             origin.y += height / 2.0;
                         }
-                        VelloTextAlignment::Top => {
+                        VelloTextAnchor::Top => {
                             origin.x += -width / 2.0;
                             origin.y += height;
                         }
-                        VelloTextAlignment::Center => {
+                        VelloTextAnchor::Center => {
                             origin.x += -width / 2.0;
                             origin.y += height / 2.0;
                         }
-                        VelloTextAlignment::TopRight => {
+                        VelloTextAnchor::TopRight => {
                             origin.x += -width;
                             origin.y += height;
                         }
-                        VelloTextAlignment::Right => {
+                        VelloTextAnchor::Right => {
                             origin.x += -width;
                             origin.y += height / 2.0;
                         }

--- a/src/integrations/asset.rs
+++ b/src/integrations/asset.rs
@@ -41,9 +41,9 @@ impl VelloAsset {
     }
 }
 
-/// Describes how to position the asset from the origin
+/// Describes how the asset is positioned relative to its [`Transform`]. It defaults to [`VelloAssetAnchor::Center`].
 #[derive(Component, Default, Clone, Copy, PartialEq, Eq)]
-pub enum VelloAssetAlignment {
+pub enum VelloAssetAnchor {
     /// Bounds start from the render position and advance up and to the right.
     BottomLeft,
     /// Bounds start from the render position and advance up.
@@ -67,24 +67,24 @@ pub enum VelloAssetAlignment {
     TopRight,
 }
 
-impl VelloAssetAlignment {
+impl VelloAssetAnchor {
     pub(crate) fn compute(
         &self,
         asset: &VelloAsset,
         transform: &GlobalTransform,
     ) -> GlobalTransform {
         let (width, height) = (asset.width, asset.height);
-        // Apply alignment
+        // Apply positioning
         let adjustment = match self {
-            VelloAssetAlignment::TopLeft => Vec3::new(width / 2.0, -height / 2.0, 0.0),
-            VelloAssetAlignment::Left => Vec3::new(width / 2.0, 0.0, 0.0),
-            VelloAssetAlignment::BottomLeft => Vec3::new(width / 2.0, height / 2.0, 0.0),
-            VelloAssetAlignment::Top => Vec3::new(0.0, -height / 2.0, 0.0),
-            VelloAssetAlignment::Center => Vec3::new(0.0, 0.0, 0.0),
-            VelloAssetAlignment::Bottom => Vec3::new(0.0, height / 2.0, 0.0),
-            VelloAssetAlignment::TopRight => Vec3::new(-width / 2.0, -height / 2.0, 0.0),
-            VelloAssetAlignment::Right => Vec3::new(-width / 2.0, 0.0, 0.0),
-            VelloAssetAlignment::BottomRight => Vec3::new(-width / 2.0, height / 2.0, 0.0),
+            VelloAssetAnchor::TopLeft => Vec3::new(width / 2.0, -height / 2.0, 0.0),
+            VelloAssetAnchor::Left => Vec3::new(width / 2.0, 0.0, 0.0),
+            VelloAssetAnchor::BottomLeft => Vec3::new(width / 2.0, height / 2.0, 0.0),
+            VelloAssetAnchor::Top => Vec3::new(0.0, -height / 2.0, 0.0),
+            VelloAssetAnchor::Center => Vec3::new(0.0, 0.0, 0.0),
+            VelloAssetAnchor::Bottom => Vec3::new(0.0, height / 2.0, 0.0),
+            VelloAssetAnchor::TopRight => Vec3::new(-width / 2.0, -height / 2.0, 0.0),
+            VelloAssetAnchor::Right => Vec3::new(-width / 2.0, 0.0, 0.0),
+            VelloAssetAnchor::BottomRight => Vec3::new(-width / 2.0, height / 2.0, 0.0),
         };
         let new_translation: Vec3 = (transform.compute_matrix() * adjustment.extend(1.0)).xyz();
         GlobalTransform::from(

--- a/src/integrations/lottie/asset_loader.rs
+++ b/src/integrations/lottie/asset_loader.rs
@@ -39,13 +39,13 @@ impl AssetLoader for VelloLottieLoader {
             debug!("parsing {}...", load_context.path().display());
             match ext {
                 "json" => {
-                    let vello_vector = load_lottie_from_bytes(&bytes)?;
+                    let asset = load_lottie_from_bytes(&bytes)?;
                     info!(
                         path = format!("{}", load_context.path().display()),
-                        size = format!("{:?}", (vello_vector.width, vello_vector.height)),
+                        size = format!("{:?}", (asset.width, asset.height)),
                         "finished parsing lottie json asset"
                     );
-                    Ok(vello_vector)
+                    Ok(asset)
                 }
                 ext => Err(VectorLoaderError::Io(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,

--- a/src/integrations/lottie/parse.rs
+++ b/src/integrations/lottie/parse.rs
@@ -10,7 +10,7 @@ pub fn load_lottie_from_bytes(bytes: &[u8]) -> Result<VelloAsset, VectorLoaderEr
     let width = composition.width as f32;
     let height = composition.height as f32;
 
-    let vello_vector = VelloAsset {
+    let asset = VelloAsset {
         file: VectorFile::Lottie(Arc::new(composition)),
         local_transform_center: {
             let mut transform = Transform::default();
@@ -23,7 +23,7 @@ pub fn load_lottie_from_bytes(bytes: &[u8]) -> Result<VelloAsset, VectorLoaderEr
         alpha: 1.0,
     };
 
-    Ok(vello_vector)
+    Ok(asset)
 }
 
 /// Deserialize a Lottie file from a string slice.

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -18,7 +18,7 @@ mod error;
 pub use error::VectorLoaderError;
 
 mod asset;
-pub use asset::{VelloAsset, VelloAssetAlignment};
+pub use asset::{VelloAsset, VelloAssetAnchor};
 
 #[derive(Clone)]
 pub enum VectorFile {

--- a/src/integrations/svg/asset_loader.rs
+++ b/src/integrations/svg/asset_loader.rs
@@ -39,13 +39,13 @@ impl AssetLoader for VelloSvgLoader {
             debug!("parsing {}...", load_context.path().display());
             match ext {
                 "svg" => {
-                    let vello_vector = load_svg_from_bytes(&bytes)?;
+                    let asset = load_svg_from_bytes(&bytes)?;
                     info!(
                         path = format!("{}", load_context.path().display()),
-                        size = format!("{:?}", (vello_vector.width, vello_vector.height)),
+                        size = format!("{:?}", (asset.width, asset.height)),
                         "finished parsing svg asset"
                     );
-                    Ok(vello_vector)
+                    Ok(asset)
                 }
                 ext => Err(VectorLoaderError::Io(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,

--- a/src/integrations/svg/parse.rs
+++ b/src/integrations/svg/parse.rs
@@ -17,7 +17,7 @@ pub fn load_svg_from_bytes(bytes: &[u8]) -> Result<VelloAsset, VectorLoaderError
     let width = tree.size().width();
     let height = tree.size().height();
 
-    let vello_vector = VelloAsset {
+    let asset = VelloAsset {
         file: VectorFile::Svg(Arc::new(scene)),
         local_transform_center: {
             let mut transform = Transform::default();
@@ -30,7 +30,7 @@ pub fn load_svg_from_bytes(bytes: &[u8]) -> Result<VelloAsset, VectorLoaderError
         alpha: 1.0,
     };
 
-    Ok(vello_vector)
+    Ok(asset)
 }
 
 /// Deserialize an SVG file from a string slice.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@ pub mod prelude {
 
     pub use crate::{
         debug::DebugVisualizations,
-        integrations::{VectorFile, VelloAsset, VelloAssetAlignment},
+        integrations::{VectorFile, VelloAsset, VelloAssetAnchor},
         render::VelloCanvasMaterial,
-        text::{VelloFont, VelloText, VelloTextAlignment},
+        text::{VelloFont, VelloText, VelloTextAnchor},
         CoordinateSpace, VelloAssetBundle, VelloScene, VelloSceneBundle, VelloTextBundle,
     };
 
@@ -50,9 +50,9 @@ pub enum CoordinateSpace {
 #[derive(Bundle, Default)]
 pub struct VelloAssetBundle {
     /// Asset data to render
-    pub vector: Handle<VelloAsset>,
-    /// How the bounding asset is aligned, respective to the transform.
-    pub alignment: VelloAssetAlignment,
+    pub asset: Handle<VelloAsset>,
+    /// How the asset is positioned relative to its [`Transform`].
+    pub asset_anchor: VelloAssetAnchor,
     /// The coordinate space in which this vector should be rendered.
     pub coordinate_space: CoordinateSpace,
     /// A transform to apply to this vector
@@ -95,8 +95,8 @@ pub struct VelloTextBundle {
     pub font: Handle<VelloFont>,
     /// Text to render
     pub text: VelloText,
-    /// How the bounding text is aligned, respective to the transform.
-    pub alignment: VelloTextAlignment,
+    /// How the text is positioned relative to its [`Transform`].
+    pub text_anchor: VelloTextAnchor,
     /// The coordinate space in which this text should be rendered.
     pub coordinate_space: CoordinateSpace,
     /// A transform to apply to this text

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,6 +1,6 @@
 use crate::{
-    text::VelloTextAlignment, CoordinateSpace, VelloAsset, VelloAssetAlignment, VelloFont,
-    VelloScene, VelloText,
+    text::VelloTextAnchor, CoordinateSpace, VelloAsset, VelloAssetAnchor, VelloFont, VelloScene,
+    VelloText,
 };
 use bevy::{
     prelude::*,
@@ -11,7 +11,7 @@ use bevy::{
 #[derive(Component, Clone)]
 pub struct ExtractedRenderAsset {
     pub asset: VelloAsset,
-    pub alignment: VelloAssetAlignment,
+    pub asset_anchor: VelloAssetAnchor,
     pub transform: GlobalTransform,
     pub render_mode: CoordinateSpace,
     pub ui_node: Option<Node>,
@@ -28,7 +28,7 @@ pub fn extract_svg_instances(
     query_vectors: Extract<
         Query<(
             &Handle<VelloAsset>,
-            &VelloAssetAlignment,
+            &VelloAssetAnchor,
             &CoordinateSpace,
             &GlobalTransform,
             Option<&Node>,
@@ -39,8 +39,8 @@ pub fn extract_svg_instances(
     assets: Extract<Res<Assets<VelloAsset>>>,
 ) {
     for (
-        vello_vector_handle,
-        alignment,
+        asset,
+        asset_anchor,
         coord_space,
         transform,
         ui_node,
@@ -54,13 +54,13 @@ pub fn extract_svg_instances(
                 alpha,
                 ..
             },
-        ) = assets.get(vello_vector_handle)
+        ) = assets.get(asset)
         {
             if view_visibility.get() && inherited_visibility.get() {
                 commands.spawn(ExtractedRenderAsset {
                     asset: asset.to_owned(),
                     transform: *transform,
-                    alignment: *alignment,
+                    asset_anchor: *asset_anchor,
                     render_mode: *coord_space,
                     ui_node: ui_node.cloned(),
                     alpha: *alpha,
@@ -80,7 +80,7 @@ pub fn extract_lottie_instances(
     query_vectors: Extract<
         Query<(
             &Handle<VelloAsset>,
-            &VelloAssetAlignment,
+            &VelloAssetAnchor,
             &CoordinateSpace,
             &GlobalTransform,
             &crate::Playhead,
@@ -93,8 +93,8 @@ pub fn extract_lottie_instances(
     assets: Extract<Res<Assets<VelloAsset>>>,
 ) {
     for (
-        vello_vector_handle,
-        alignment,
+        asset,
+        asset_anchor,
         coord_space,
         transform,
         playhead,
@@ -110,14 +110,14 @@ pub fn extract_lottie_instances(
                 alpha,
                 ..
             },
-        ) = assets.get(vello_vector_handle)
+        ) = assets.get(asset)
         {
             if view_visibility.get() && inherited_visibility.get() {
                 let playhead = playhead.frame();
                 commands.spawn(ExtractedRenderAsset {
                     asset: asset.to_owned(),
                     transform: *transform,
-                    alignment: *alignment,
+                    asset_anchor: *asset_anchor,
                     theme: theme.cloned(),
                     render_mode: *coord_space,
                     playhead,
@@ -168,7 +168,7 @@ pub fn scene_instances(
 pub struct ExtractedRenderText {
     pub font: Handle<VelloFont>,
     pub text: VelloText,
-    pub alignment: VelloTextAlignment,
+    pub text_anchor: VelloTextAnchor,
     pub transform: GlobalTransform,
     pub render_mode: CoordinateSpace,
 }
@@ -177,7 +177,7 @@ impl ExtractComponent for ExtractedRenderText {
     type QueryData = (
         &'static Handle<VelloFont>,
         &'static VelloText,
-        &'static VelloTextAlignment,
+        &'static VelloTextAnchor,
         &'static GlobalTransform,
         &'static CoordinateSpace,
     );
@@ -187,7 +187,7 @@ impl ExtractComponent for ExtractedRenderText {
     type Out = Self;
 
     fn extract_component(
-        (vello_font_handle, text, alignment, transform, render_mode): bevy::ecs::query::QueryItem<
+        (vello_font_handle, text, text_anchor, transform, render_mode): bevy::ecs::query::QueryItem<
             '_,
             Self::QueryData,
         >,
@@ -195,7 +195,7 @@ impl ExtractComponent for ExtractedRenderText {
         Some(Self {
             font: vello_font_handle.clone(),
             text: text.clone(),
-            alignment: *alignment,
+            text_anchor: *text_anchor,
             transform: *transform,
             render_mode: *render_mode,
         })

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -58,7 +58,7 @@ pub fn setup_image(images: &mut Assets<Image>, window: &WindowResolution) -> Han
 #[allow(clippy::complexity)]
 pub fn render_scene(
     ss_render_target: Query<&SSRenderTarget>,
-    query_render_vectors: Query<(&PreparedAffine, &ExtractedRenderAsset)>,
+    query_render_assets: Query<(&PreparedAffine, &ExtractedRenderAsset)>,
     query_render_scenes: Query<(&PreparedAffine, &ExtractedRenderScene)>,
     query_render_texts: Query<(&PreparedAffine, &ExtractedRenderText)>,
     mut font_render_assets: ResMut<RenderAssets<VelloFont>>,
@@ -95,7 +95,7 @@ pub fn render_scene(
         Scene(&'a ExtractedRenderScene),
         Text(&'a ExtractedRenderText),
     }
-    let mut render_queue: Vec<(f32, CoordinateSpace, (Affine, RenderItem))> = query_render_vectors
+    let mut render_queue: Vec<(f32, CoordinateSpace, (Affine, RenderItem))> = query_render_assets
         .iter()
         .map(|(&affine, asset)| {
             (
@@ -207,11 +207,11 @@ pub fn render_scene(
             RenderItem::Text(ExtractedRenderText {
                 font,
                 text,
-                alignment,
+                text_anchor,
                 ..
             }) => {
                 if let Some(font) = font_render_assets.get_mut(font) {
-                    font.render(&mut scene_buffer, *affine, text, *alignment);
+                    font.render(&mut scene_buffer, *affine, text, *text_anchor);
                 }
             }
         }

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -1,4 +1,4 @@
-use super::{vello_text::VelloText, VelloTextAlignment};
+use super::{vello_text::VelloText, VelloTextAnchor};
 use bevy::{prelude::*, reflect::TypePath, render::render_asset::RenderAsset};
 use std::sync::Arc;
 use vello::{
@@ -75,7 +75,7 @@ impl VelloFont {
         scene: &mut Scene,
         mut transform: Affine,
         text: &VelloText,
-        alignment: VelloTextAlignment,
+        text_anchor: VelloTextAnchor,
     ) {
         let font = FontRef::new(self.font.data.data()).expect("Vello font creation error");
 
@@ -117,32 +117,32 @@ impl VelloFont {
         // Alignment settings
         let width = width as f64;
         let height = (metrics.cap_height.unwrap_or(line_height) + pen_y) as f64;
-        match alignment {
-            VelloTextAlignment::TopLeft => {
+        match text_anchor {
+            VelloTextAnchor::TopLeft => {
                 transform *= vello::kurbo::Affine::translate((0.0, height));
             }
-            VelloTextAlignment::Left => {
+            VelloTextAnchor::Left => {
                 transform *= vello::kurbo::Affine::translate((0.0, height / 2.0));
             }
-            VelloTextAlignment::BottomLeft => {
+            VelloTextAnchor::BottomLeft => {
                 transform *= vello::kurbo::Affine::translate((0.0, 0.0));
             }
-            VelloTextAlignment::Top => {
+            VelloTextAnchor::Top => {
                 transform *= vello::kurbo::Affine::translate((-width / 2.0, height));
             }
-            VelloTextAlignment::Center => {
+            VelloTextAnchor::Center => {
                 transform *= vello::kurbo::Affine::translate((-width / 2.0, height / 2.0));
             }
-            VelloTextAlignment::Bottom => {
+            VelloTextAnchor::Bottom => {
                 transform *= vello::kurbo::Affine::translate((-width / 2.0, 0.0));
             }
-            VelloTextAlignment::TopRight => {
+            VelloTextAnchor::TopRight => {
                 transform *= vello::kurbo::Affine::translate((-width, height));
             }
-            VelloTextAlignment::Right => {
+            VelloTextAnchor::Right => {
                 transform *= vello::kurbo::Affine::translate((-width, height / 2.0));
             }
-            VelloTextAlignment::BottomRight => {
+            VelloTextAnchor::BottomRight => {
                 transform *= vello::kurbo::Affine::translate((-width, 0.0));
             }
         }

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -6,4 +6,4 @@ mod vello_text;
 
 pub use font::VelloFont;
 pub(crate) use font_loader::VelloFontLoader;
-pub use vello_text::{VelloText, VelloTextAlignment};
+pub use vello_text::{VelloText, VelloTextAnchor};

--- a/src/text/vello_text.rs
+++ b/src/text/vello_text.rs
@@ -2,9 +2,9 @@ use crate::VelloFont;
 use bevy::prelude::*;
 use vello::peniko::Brush;
 
-/// Describes how to position text from the origin
+/// Describes how the text is positioned relative to its [`Transform`]. It defaults to [`VelloTextAnchor::BottomLeft`].
 #[derive(Component, Default, Clone, Copy, PartialEq, Eq)]
-pub enum VelloTextAlignment {
+pub enum VelloTextAnchor {
     /// Bounds start from the render position and advance up and to the right.
     #[default]
     BottomLeft,


### PR DESCRIPTION
Renames `Alignment`s to `Anchor`s. This is consistent with how bevy names the equivalent component, `Anchor` within `Text2dBundle`. (https://docs.rs/bevy/latest/bevy/text/struct.Text2dBundle.html).

Also, this corrects and consistently names fields in the internals, not in the public API.