### PR TITLE
Show RenderLayers changes

### DIFF
--- a/examples/render_layers/Cargo.toml
+++ b/examples/render_layers/Cargo.toml
@@ -10,3 +10,4 @@ publish = false
 [dependencies]
 bevy_vello = { path = "../../" }
 bevy = { workspace = true, features = ["bevy_gizmos"] }
+bevy-inspector-egui = "0.25"

--- a/examples/render_layers/src/main.rs
+++ b/examples/render_layers/src/main.rs
@@ -7,7 +7,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(VelloPlugin)
-        .add_systems(Startup, (setup_animation, setup_background))
+        .add_plugins(bevy_inspector_egui::quick::WorldInspectorPlugin::default())
+        .add_systems(Startup, (setup_gizmos, setup_animation, setup_background))
         .add_systems(
             Update,
             (
@@ -18,6 +19,11 @@ fn main() {
             ),
         )
         .run();
+}
+
+fn setup_gizmos(mut config_store: ResMut<GizmoConfigStore>) {
+    let (config, _) = config_store.config_mut::<DefaultGizmoConfigGroup>();
+    config.render_layers = RenderLayers::layer(1);
 }
 
 /// A tag that will mark the scene on RenderLayer 0.
@@ -33,7 +39,7 @@ struct Layer1Scene;
 struct Layer2Scene;
 
 fn setup_animation(mut commands: Commands) {
-    const LAYER_0: RenderLayers = RenderLayers::layer(0);
+    // const LAYER_0: RenderLayers = RenderLayers::layer(0);
     const LAYER_1: RenderLayers = RenderLayers::layer(1);
 
     // This camera can see everything on Layer 1 and Layer 2.
@@ -46,10 +52,11 @@ fn setup_animation(mut commands: Commands) {
             },
             ..default()
         },
-        LAYER_0.union(&LAYER_1),
+        // LAYER_0.union(&LAYER_1),
+        LAYER_1,
     ));
 
-    commands.spawn((VelloSceneBundle::default(), Layer0Scene, LAYER_0));
+    commands.spawn((VelloSceneBundle::default(), Layer0Scene, LAYER_1));
     commands.spawn((VelloSceneBundle::default(), Layer1Scene, LAYER_1));
 }
 

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -321,12 +321,13 @@ pub fn setup_ss_rendertarget(
         .spawn(MaterialMesh2dBundle {
             mesh,
             material,
-            transform: Transform::from_translation(0.001 * Vec3::NEG_Z), /* Make sure the vello
-                                                                          * canvas renders behind
-                                                                          * Gizmos */
+            // transform: Transform::from_translation(0.001 * Vec3::NEG_Z), /* Make sure the vello
+            //                                                               * canvas renders behind
+            //                                                               * Gizmos */
             ..Default::default()
         })
         .insert(NoFrustumCulling)
+        .insert(RenderLayers::layer(1))
         .insert(render_target);
 }
 


### PR DESCRIPTION
This is less of a PR I see merging and more intended to show what's happening in an easy to run way (by modifying the renderlayers example) and what specifically needs to change. I'm following it up with an actual PR ( #71 ) for a fix.

RenderLayers mostly work, but the example uses layer 0 which is [the default layer](https://docs.rs/bevy_render/0.14.0/src/bevy_render/view/visibility/render_layers.rs.html#32) for Bevy, which makes it a bit confusing. One reason is that the gizmos in the example will render on layer 0 by default, which is why I believe the transform was previously required. The vello canvas will also render on 0.

If you configure the gizmos to be layer 1 and don't place anything on layer 0 it becomes clear that the mesh rendering the canvas needs to be placed on an applicable layer. In this case I've hardcoded it to 1 but any RenderLayer associated with a camera works. In this example that means layer 1 or 2. Placing it on layer 0 or 3+ will result in just the gizmos rendering, as expected since gizmos aren't handled by vello and are configured for layer 1.