### PR TITLE
feat: add `SkipEncoding`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - There is now a `cube_3d` example.
 - You may now choose the render layers for the Vello canvas. This can be configured through the `VelloPlugin`.
 - You may now choose to use CPU rendering with Vello and configure anti-aliasing. This can be configured through the `VelloPlugin`.
+- Added the `SkipEncoding` component, which allows you to skip encoding any renderable asset without removing the asset.
 
 ### Changed
 

--- a/examples/scene/src/main.rs
+++ b/examples/scene/src/main.rs
@@ -1,9 +1,5 @@
 use bevy::prelude::*;
-use bevy_vello::{
-    prelude::*,
-    vello::{kurbo, peniko},
-    VelloPlugin,
-};
+use bevy_vello::{prelude::*, VelloPlugin};
 
 fn main() {
     App::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod prelude {
     pub use crate::{
         debug::DebugVisualizations,
         integrations::{VectorFile, VelloAsset, VelloAssetAnchor},
-        render::VelloRenderSettings,
+        render::{SkipEncoding, VelloRenderSettings},
         text::{VelloFont, VelloTextAnchor, VelloTextSection, VelloTextStyle},
         CoordinateSpace, VelloAssetBundle, VelloScene, VelloSceneBundle, VelloTextBundle,
     };

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,7 +1,4 @@
-use crate::{
-    text::VelloTextAnchor, CoordinateSpace, VelloAsset, VelloAssetAnchor, VelloScene,
-    VelloTextSection,
-};
+use crate::prelude::*;
 use bevy::{
     prelude::*,
     render::{extract_component::ExtractComponent, view::RenderLayers, Extract},
@@ -27,16 +24,19 @@ pub struct ExtractedRenderAsset {
 pub fn extract_svg_assets(
     mut commands: Commands,
     query_vectors: Extract<
-        Query<(
-            &Handle<VelloAsset>,
-            &VelloAssetAnchor,
-            &CoordinateSpace,
-            &GlobalTransform,
-            Option<&Node>,
-            Option<&RenderLayers>,
-            &ViewVisibility,
-            &InheritedVisibility,
-        )>,
+        Query<
+            (
+                &Handle<VelloAsset>,
+                &VelloAssetAnchor,
+                &CoordinateSpace,
+                &GlobalTransform,
+                Option<&Node>,
+                Option<&RenderLayers>,
+                &ViewVisibility,
+                &InheritedVisibility,
+            ),
+            Without<SkipEncoding>,
+        >,
     >,
     assets: Extract<Res<Assets<VelloAsset>>>,
 ) {
@@ -82,18 +82,21 @@ pub fn extract_svg_assets(
 pub fn extract_lottie_assets(
     mut commands: Commands,
     query_vectors: Extract<
-        Query<(
-            &Handle<VelloAsset>,
-            &VelloAssetAnchor,
-            &CoordinateSpace,
-            &GlobalTransform,
-            &crate::Playhead,
-            Option<&crate::Theme>,
-            Option<&Node>,
-            Option<&RenderLayers>,
-            &ViewVisibility,
-            &InheritedVisibility,
-        )>,
+        Query<
+            (
+                &Handle<VelloAsset>,
+                &VelloAssetAnchor,
+                &CoordinateSpace,
+                &GlobalTransform,
+                &crate::Playhead,
+                Option<&crate::Theme>,
+                Option<&Node>,
+                Option<&RenderLayers>,
+                &ViewVisibility,
+                &InheritedVisibility,
+            ),
+            Without<SkipEncoding>,
+        >,
     >,
     assets: Extract<Res<Assets<VelloAsset>>>,
 ) {
@@ -148,15 +151,18 @@ pub struct ExtractedRenderScene {
 pub fn extract_scenes(
     mut commands: Commands,
     query_scenes: Extract<
-        Query<(
-            &VelloScene,
-            &CoordinateSpace,
-            &GlobalTransform,
-            &ViewVisibility,
-            &InheritedVisibility,
-            Option<&Node>,
-            Option<&RenderLayers>,
-        )>,
+        Query<
+            (
+                &VelloScene,
+                &CoordinateSpace,
+                &GlobalTransform,
+                &ViewVisibility,
+                &InheritedVisibility,
+                Option<&Node>,
+                Option<&RenderLayers>,
+            ),
+            Without<SkipEncoding>,
+        >,
     >,
 ) {
     for (

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -142,3 +142,7 @@ pub(crate) struct VelloCanvasSettings {
     /// The render layers that will be used for the Vello canvas mesh.
     pub render_layers: RenderLayers,
 }
+
+/// Add this to any renderable vello asset to skip encoding that renderable.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct SkipEncoding;


### PR DESCRIPTION
Adds the `SkipEncoding` component which allows us to skip rendering any renderable entity