### PR TITLE
fix: skip text when `SkipEncoding` is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,6 @@ You can find its changes [documented below](#051---2024-07-04).
 
 This release supports Bevy version 0.14 and has an [MSRV][] of 1.80.
 
-## [0.6.1] - 2024-08-14
-
-This release supports Bevy version 0.14 and has an [MSRV][] of 1.80.
-
 ### Fixed
 
 - Text is now properly skipped when a `SkipEncoding` component is present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ You can find its changes [documented below](#051---2024-07-04).
 
 This release supports Bevy version 0.14 and has an [MSRV][] of 1.80.
 
+## [0.6.1] - 2024-08-14
+
+This release supports Bevy version 0.14 and has an [MSRV][] of 1.80.
+
+### Fixed
+
+- Text is now properly skipped when a `SkipEncoding` component is present.
+
 ## [0.6.0] - 2024-08-09
 
 This release supports Bevy version 0.14 and has an [MSRV][] of 1.80.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This release supports Bevy version 0.14 and has an [MSRV][] of 1.80.
 
 ### Fixed
 
-- Text is now properly skipped when a `SkipEncoding` component is present.
+- Text is now properly skipped when a `SkipEncoding` component is present. ([#77] by [@simbleau])
 
 ## [0.6.0] - 2024-08-09
 
@@ -228,6 +228,10 @@ This release supports Bevy version 0.13 and has an [MSRV][] of 1.77.
 This release supports Bevy version 0.13 and has an [MSRV][] of 1.77.
 
 - Initial release
+
+[#77]: https://github.com/linebender/bevy_vello/pull/77
+
+[@simbleau]: https://github.com/simbleau
 
 [Unreleased]: https://github.com/linebender/bevy_vello/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/linebender/bevy_vello/compare/v0.5.1...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.6.0"
+version = "0.6.1"
 license = "(MIT OR Apache-2.0) AND OFL-1.1"
 repository = "https://github.com/linebender/bevy_vello"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.6.1"
+version = "0.6.0"
 license = "(MIT OR Apache-2.0) AND OFL-1.1"
 repository = "https://github.com/linebender/bevy_vello"
 

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -199,15 +199,18 @@ pub struct ExtractedRenderText {
 pub fn extract_text(
     mut commands: Commands,
     query_scenes: Extract<
-        Query<(
-            &VelloTextSection,
-            &VelloTextAnchor,
-            &GlobalTransform,
-            &ViewVisibility,
-            &InheritedVisibility,
-            &CoordinateSpace,
-            Option<&RenderLayers>,
-        )>,
+        Query<
+            (
+                &VelloTextSection,
+                &VelloTextAnchor,
+                &GlobalTransform,
+                &ViewVisibility,
+                &InheritedVisibility,
+                &CoordinateSpace,
+                Option<&RenderLayers>,
+            ),
+            Without<SkipEncoding>,
+        >,
     >,
 ) {
     for (


### PR DESCRIPTION
Text is now properly skipped when a `SkipEncoding` component is present.