### PR TITLE
Require a VelloView marker for cameras rendering Vello graphics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,14 @@ You can find its changes [documented below](#061---2024-08-14).
 
 This release supports Bevy version 0.14 and has an [MSRV][] of 1.80.
 
+### Added
+
+- Added `VelloView` marker component used for identifying cameras rendering vello content.
+
 ### Changed
 
 - bevy_vello now uses Bevy 0.15
+- `Camera2d` now requires a `VelloView` marker for rendering.
 - `VelloAsset` assets have been separated into `VelloSvg` and `VelloLottie`
 - `VelloAssetBundle` has been separated into `VelloSvgBundle` and `VelloLottieBundle`
 - `Handle<VelloAsset>` has been separated into `VelloSvgHandle` and `VelloLottieHandle`

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
 }
 
 fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServer>) {
-    commands.spawn((Camera2d, bevy_pancam::PanCam::default()));
+    commands.spawn((Camera2d, bevy_pancam::PanCam::default(), VelloView));
     commands
         .spawn(VelloLottieBundle {
             asset: VelloLottieHandle(asset_server.load("embedded://demo/assets/calendar.json")),

--- a/examples/drag_n_drop/src/main.rs
+++ b/examples/drag_n_drop/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
 }
 
 fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServer>) {
-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, VelloView));
 
     commands.spawn(VelloSvgBundle {
         asset: VelloSvgHandle(asset_server.load("embedded://drag_n_drop/assets/fountain.svg")),

--- a/examples/lottie/src/main.rs
+++ b/examples/lottie/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
 }
 
 fn load_lottie(mut commands: Commands, asset_server: ResMut<AssetServer>) {
-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, VelloView));
 
     // Yes, it's this simple.
     commands.spawn(VelloLottieBundle {

--- a/examples/render_layers/src/main.rs
+++ b/examples/render_layers/src/main.rs
@@ -33,6 +33,7 @@ fn setup_gizmos(mut commands: Commands, mut config_store: ResMut<GizmoConfigStor
             ..default()
         },
         RenderLayers::layer(3),
+        VelloView,
     ));
     let (config, _) = config_store.config_mut::<DefaultGizmoConfigGroup>();
     config.render_layers = RenderLayers::layer(3);
@@ -47,6 +48,7 @@ fn setup_scene(mut commands: Commands) {
             ..default()
         },
         RenderLayers::layer(1).with(2),
+        VelloView,
     ));
 
     commands.spawn((

--- a/examples/scene/src/main.rs
+++ b/examples/scene/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
 }
 
 fn setup_vector_graphics(mut commands: Commands) {
-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, VelloView));
     commands.spawn(VelloSceneBundle::default());
 }
 

--- a/examples/scene_ui/src/main.rs
+++ b/examples/scene_ui/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
 }
 
 fn setup_ui(mut commands: Commands) {
-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, VelloView));
 
     let one_third = Val::Percent(100.0 / 3.0);
     commands.spawn((

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
 }
 
 fn load_svg(mut commands: Commands, asset_server: ResMut<AssetServer>) {
-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, VelloView));
 
     // Yes, it's this simple.
     commands.spawn(VelloSvgBundle {

--- a/examples/text/src/main.rs
+++ b/examples/text/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn setup_camera(mut commands: Commands) {
-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, VelloView));
 }
 
 fn setup_worldspace_text(mut commands: Commands, asset_server: ResMut<AssetServer>) {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -42,7 +42,10 @@ fn render_svg_debug(
         Without<Node>,
     >,
     assets: Res<Assets<VelloSvg>>,
-    query_cam: Query<(&Camera, &GlobalTransform, &OrthographicProjection), With<Camera2d>>,
+    query_cam: Query<
+        (&Camera, &GlobalTransform, &OrthographicProjection),
+        (With<Camera2d>, With<VelloView>),
+    >,
     mut gizmos: Gizmos,
 ) {
     let Ok((camera, view, projection)) = query_cam.get_single() else {
@@ -162,7 +165,10 @@ fn render_text_debug(
         ),
         Without<Node>,
     >,
-    query_cam: Query<(&Camera, &GlobalTransform, &OrthographicProjection), With<Camera2d>>,
+    query_cam: Query<
+        (&Camera, &GlobalTransform, &OrthographicProjection),
+        (With<Camera2d>, With<VelloView>),
+    >,
     fonts: Res<Assets<VelloFont>>,
     mut gizmos: Gizmos,
 ) {

--- a/src/integrations/dot_lottie/systems.rs
+++ b/src/integrations/dot_lottie/systems.rs
@@ -5,6 +5,7 @@ use crate::{
         PlaybackPlayMode,
     },
     PlaybackDirection, PlaybackLoopBehavior, PlaybackOptions, PlayerTransition, Playhead,
+    VelloView,
 };
 use bevy::{prelude::*, utils::Instant};
 use std::time::Duration;
@@ -146,7 +147,7 @@ pub fn run_transitions(
     )>,
     mut assets: ResMut<Assets<VelloLottie>>,
     windows: Query<&Window>,
-    query_view: Query<(&Camera, &GlobalTransform), With<Camera2d>>,
+    query_view: Query<(&Camera, &GlobalTransform), (With<Camera2d>, With<VelloView>)>,
     buttons: Res<ButtonInput<MouseButton>>,
     mut hovered: Local<bool>,
 ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod prelude {
 
     pub use crate::{
         debug::DebugVisualizations,
-        render::{SkipEncoding, VelloRenderSettings},
+        render::{SkipEncoding, VelloRenderSettings, VelloView},
         text::{VelloFont, VelloTextAnchor, VelloTextSection, VelloTextStyle},
         CoordinateSpace, VelloScene, VelloSceneBundle, VelloTextBundle,
     };

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3,6 +3,7 @@
 use bevy::{
     prelude::*,
     render::{
+        extract_component::ExtractComponent,
         mesh::MeshVertexBufferLayoutRef,
         render_resource::{
             AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
@@ -26,6 +27,10 @@ pub(crate) use plugin::VelloRenderPlugin;
 
 /// A handle to the screen space render target shader.
 pub const SSRT_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(2314894693238056781);
+
+/// A component that should be added to the camera that will render Vello assets.
+#[derive(Component, Debug, Clone, Copy, ExtractComponent)]
+pub struct VelloView;
 
 /// A canvas material, with a shader that samples a texture with view-independent UV coordinates.
 #[derive(AsBindGroup, TypePath, Asset, Clone)]

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     render::{VelloCanvasMaterial, VelloRenderer, SSRT_SHADER_HANDLE},
-    VelloFont, VelloScene, VelloTextSection,
+    VelloFont, VelloScene, VelloTextSection, VelloView,
 };
 use bevy::{
     asset::load_internal_asset,
@@ -70,6 +70,8 @@ impl Plugin for VelloRenderPlugin {
                     .in_set(RenderSet::Render)
                     .run_if(resource_exists::<RenderDevice>),
             );
+
+        app.add_plugins(ExtractComponentPlugin::<VelloView>::default());
 
         app.insert_resource(self.canvas_settings.clone())
             .add_plugins((

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -1,4 +1,7 @@
-use super::extract::{ExtractedPixelScale, ExtractedRenderScene, ExtractedRenderText};
+use super::{
+    extract::{ExtractedPixelScale, ExtractedRenderScene, ExtractedRenderText},
+    VelloView,
+};
 use crate::CoordinateSpace;
 use bevy::{
     prelude::*,
@@ -30,7 +33,10 @@ pub trait PrepareRenderInstance {
 
 pub fn prepare_scene_affines(
     mut commands: Commands,
-    views: Query<(&ExtractedCamera, &ExtractedView, Option<&RenderLayers>), With<Camera2d>>,
+    views: Query<
+        (&ExtractedCamera, &ExtractedView, Option<&RenderLayers>),
+        (With<Camera2d>, With<VelloView>),
+    >,
     render_entities: Query<(Entity, &ExtractedRenderScene)>,
 ) {
     for (camera, view, maybe_camera_layers) in views.iter() {
@@ -118,7 +124,10 @@ pub fn prepare_scene_affines(
 
 pub fn prepare_text_affines(
     mut commands: Commands,
-    views: Query<(&ExtractedCamera, &ExtractedView, Option<&RenderLayers>), With<Camera2d>>,
+    views: Query<
+        (&ExtractedCamera, &ExtractedView, Option<&RenderLayers>),
+        (With<Camera2d>, With<VelloView>),
+    >,
     render_entities: Query<(Entity, &ExtractedRenderText)>,
     pixel_scale: Res<ExtractedPixelScale>,
 ) {

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -1,7 +1,7 @@
 use super::{
     extract::{ExtractedRenderText, SSRenderTarget},
     prepare::PreparedAffine,
-    VelloCanvasMaterial, VelloCanvasSettings, VelloRenderSettings, VelloRenderer,
+    VelloCanvasMaterial, VelloCanvasSettings, VelloRenderSettings, VelloRenderer, VelloView,
 };
 use crate::{
     render::extract::ExtractedRenderScene, CoordinateSpace, VelloFont, VelloScene, VelloTextSection,
@@ -64,7 +64,7 @@ pub fn setup_image(images: &mut Assets<Image>, window: &WindowResolution) -> Han
 #[allow(clippy::complexity)]
 pub fn render_frame(
     ss_render_target: Query<&SSRenderTarget>,
-    views: Query<(&ExtractedCamera, Option<&RenderLayers>), With<Camera2d>>,
+    views: Query<(&ExtractedCamera, Option<&RenderLayers>), (With<Camera2d>, With<VelloView>)>,
     #[cfg(feature = "svg")] view_svgs: Query<(&PreparedAffine, &ExtractedSvgAsset)>,
     #[cfg(feature = "lottie")] view_lotties: Query<(&PreparedAffine, &ExtractedLottieAsset)>,
     #[cfg(feature = "lottie")] mut velato_renderer: ResMut<super::VelatoRenderer>,


### PR DESCRIPTION
It is common for Bevy cameras to mark what graphics features they use using a marker component, such as bloom or SSR, to name a few built-in effects that do this. In my game, I have cameras that don't need any Vello content at all. If I've read the logic correctly, they still pay the tax of running Vello code.

bevy_vello's `render_frame` system is currently the most demanding system in my game, and this PR seems to push it down to second place, although it is quite difficult to measure precisely.

Note that this is a breaking change, since users now have to add the `VelloView` component to their camera or nothing will render.