### PR TITLE
feat: add `VelloDiagnosticsPlugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This release supports Bevy version 0.14 and has an [MSRV][] of 1.80.
 ### Added
 
 - Added `VelloView` marker component used for identifying cameras rendering vello content.
+- Added `VelloDiagnosticsPlugin` which can be used to introspect rendering data at runtime. See the `diagnostics` example.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edf215dbb8cb1409cca7645aaed35f9e39fb0a21855bba1ac48bc0334903bf66"
 
 [[package]]
+name = "diagnostics"
+version = "0.6.1"
+dependencies = [
+ "bevy",
+ "bevy_vello",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "examples/render_layers",
   "examples/cube3d",
   "examples/headless",
+  "examples/diagnostics",
 ]
 
 [workspace.package]

--- a/examples/diagnostics/Cargo.toml
+++ b/examples/diagnostics/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "diagnostics"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+bevy_vello = { path = "../../" }
+bevy = { workspace = true }

--- a/examples/diagnostics/src/main.rs
+++ b/examples/diagnostics/src/main.rs
@@ -1,8 +1,4 @@
-use bevy::{
-    diagnostic::{Diagnostic, DiagnosticsStore},
-    prelude::*,
-    render::{Render, RenderApp, RenderSet},
-};
+use bevy::{diagnostic::DiagnosticsStore, prelude::*};
 use bevy_vello::{diagnostics::VelloDiagnosticsPlugin, prelude::*, VelloPlugin};
 use std::ops::DerefMut;
 
@@ -56,6 +52,6 @@ fn print_diagnostics(diagnostics: Res<DiagnosticsStore>) {
         .unwrap();
 
     if let Some(scene_count) = diagnostic.measurement() {
-        info!("Scenes: {}", scene_count.value);
+        info!("Total scenes: {}", scene_count.value);
     }
 }

--- a/examples/diagnostics/src/main.rs
+++ b/examples/diagnostics/src/main.rs
@@ -1,57 +1,85 @@
 use bevy::{diagnostic::DiagnosticsStore, prelude::*};
 use bevy_vello::{diagnostics::VelloDiagnosticsPlugin, prelude::*, VelloPlugin};
-use std::ops::DerefMut;
+
+const SCENE_COUNT: usize = 5;
 
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
         .add_plugins(VelloPlugin::default())
         .add_plugins(VelloDiagnosticsPlugin)
-        .add_systems(Startup, setup_vector_graphics)
+        .add_systems(Startup, setup)
         .add_systems(Update, simple_animation)
-        .add_systems(Update, print_diagnostics);
+        .add_systems(Update, update_scene_count_ui);
 
     app.run();
 }
 
-fn setup_vector_graphics(mut commands: Commands) {
+fn setup(mut commands: Commands) {
     commands.spawn((Camera2d, VelloView));
-    commands.spawn(VelloScene::new());
+    for i in 0..SCENE_COUNT {
+        commands.spawn((
+            VelloScene::new(),
+            Transform::from_translation(Vec3::new(i as f32 * 100.0 - 200.0, 0.0, 0.0)),
+        ));
+    }
+
+    // UI Text displaying the scene count
+    commands.spawn((
+        Text::new("Total Scenes: 0"),
+        TextFont {
+            font_size: 30.0,
+            ..default()
+        },
+        TextColor(Color::WHITE),
+        Node {
+            position_type: PositionType::Absolute,
+            left: Val::Px(10.0),
+            top: Val::Px(10.0),
+            ..default()
+        },
+        SceneCounterText,
+    ));
 }
 
-fn simple_animation(mut query_scene: Single<(&mut Transform, &mut VelloScene)>, time: Res<Time>) {
+#[derive(Component)]
+struct SceneCounterText;
+
+fn simple_animation(mut query: Query<(&mut Transform, &mut VelloScene)>, time: Res<Time>) {
     let sin_time = time.elapsed_secs().sin().mul_add(0.5, 0.5);
-    let (ref mut transform, ref mut scene) = query_scene.deref_mut();
-    // Reset scene every frame
-    scene.reset();
 
-    // Animate color green to blue
-    let c = Vec3::lerp(
-        Vec3::new(-1.0, 1.0, -1.0),
-        Vec3::new(-1.0, 1.0, 1.0),
-        sin_time + 0.5,
-    );
+    for (mut transform, mut scene) in query.iter_mut() {
+        scene.reset();
 
-    // Animate the corner radius
-    scene.fill(
-        peniko::Fill::NonZero,
-        kurbo::Affine::default(),
-        peniko::Color::new([c.x, c.y, c.z, 1.]),
-        None,
-        &kurbo::RoundedRect::new(-50.0, -50.0, 50.0, 50.0, (sin_time as f64) * 50.0),
-    );
+        let c = Vec3::lerp(
+            Vec3::new(-1.0, 1.0, -1.0),
+            Vec3::new(-1.0, 1.0, 1.0),
+            sin_time + 0.5,
+        );
 
-    transform.scale = Vec3::lerp(Vec3::ONE * 0.5, Vec3::ONE * 1.0, sin_time);
-    transform.translation = Vec3::lerp(Vec3::X * -100.0, Vec3::X * 100.0, sin_time);
-    transform.rotation = Quat::from_rotation_z(-std::f32::consts::TAU * sin_time);
+        scene.fill(
+            peniko::Fill::NonZero,
+            kurbo::Affine::default(),
+            peniko::Color::new([c.x, c.y, c.z, 1.]),
+            None,
+            &kurbo::RoundedRect::new(-50.0, -50.0, 50.0, 50.0, (sin_time as f64) * 50.0),
+        );
+
+        transform.scale = Vec3::lerp(Vec3::ONE * 0.5, Vec3::ONE * 1.0, sin_time);
+        transform.translation.y = sin_time * 50.0;
+        transform.rotation = Quat::from_rotation_z(-std::f32::consts::TAU * sin_time);
+    }
 }
 
-fn print_diagnostics(diagnostics: Res<DiagnosticsStore>) {
-    let diagnostic = diagnostics
-        .get(&VelloDiagnosticsPlugin::SCENE_COUNT)
-        .unwrap();
-
-    if let Some(scene_count) = diagnostic.measurement() {
-        info!("Total scenes: {}", scene_count.value);
+fn update_scene_count_ui(
+    diagnostics: Res<DiagnosticsStore>,
+    mut query: Query<&mut Text, With<SceneCounterText>>,
+) {
+    if let Some(diagnostic) = diagnostics.get(&VelloDiagnosticsPlugin::SCENE_COUNT) {
+        if let Some(scene_count) = diagnostic.measurement() {
+            for mut text in query.iter_mut() {
+                text.0 = format!("Total Scenes: {}", scene_count.value);
+            }
+        }
     }
 }

--- a/examples/diagnostics/src/main.rs
+++ b/examples/diagnostics/src/main.rs
@@ -1,0 +1,61 @@
+use bevy::{
+    diagnostic::{Diagnostic, DiagnosticsStore},
+    prelude::*,
+    render::{Render, RenderApp, RenderSet},
+};
+use bevy_vello::{diagnostics::VelloDiagnosticsPlugin, prelude::*, VelloPlugin};
+use std::ops::DerefMut;
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins)
+        .add_plugins(VelloPlugin::default())
+        .add_plugins(VelloDiagnosticsPlugin)
+        .add_systems(Startup, setup_vector_graphics)
+        .add_systems(Update, simple_animation)
+        .add_systems(Update, print_diagnostics);
+
+    app.run();
+}
+
+fn setup_vector_graphics(mut commands: Commands) {
+    commands.spawn((Camera2d, VelloView));
+    commands.spawn(VelloScene::new());
+}
+
+fn simple_animation(mut query_scene: Single<(&mut Transform, &mut VelloScene)>, time: Res<Time>) {
+    let sin_time = time.elapsed_secs().sin().mul_add(0.5, 0.5);
+    let (ref mut transform, ref mut scene) = query_scene.deref_mut();
+    // Reset scene every frame
+    scene.reset();
+
+    // Animate color green to blue
+    let c = Vec3::lerp(
+        Vec3::new(-1.0, 1.0, -1.0),
+        Vec3::new(-1.0, 1.0, 1.0),
+        sin_time + 0.5,
+    );
+
+    // Animate the corner radius
+    scene.fill(
+        peniko::Fill::NonZero,
+        kurbo::Affine::default(),
+        peniko::Color::new([c.x, c.y, c.z, 1.]),
+        None,
+        &kurbo::RoundedRect::new(-50.0, -50.0, 50.0, 50.0, (sin_time as f64) * 50.0),
+    );
+
+    transform.scale = Vec3::lerp(Vec3::ONE * 0.5, Vec3::ONE * 1.0, sin_time);
+    transform.translation = Vec3::lerp(Vec3::X * -100.0, Vec3::X * 100.0, sin_time);
+    transform.rotation = Quat::from_rotation_z(-std::f32::consts::TAU * sin_time);
+}
+
+fn print_diagnostics(diagnostics: Res<DiagnosticsStore>) {
+    let diagnostic = diagnostics
+        .get(&VelloDiagnosticsPlugin::SCENE_COUNT)
+        .unwrap();
+
+    if let Some(scene_count) = diagnostic.measurement() {
+        info!("Scenes: {}", scene_count.value);
+    }
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,41 @@
+use bevy::{
+    diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic},
+    prelude::*,
+};
+
+use crate::render::VelloFrameData;
+
+/// Adds vello diagnostics to an App, specifically asset counting and profiling.
+#[derive(Default)]
+pub struct VelloDiagnosticsPlugin;
+
+impl Plugin for VelloDiagnosticsPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_diagnostic(Diagnostic::new(Self::SCENE_COUNT))
+            .register_diagnostic(Diagnostic::new(Self::TEXT_COUNT))
+            .add_systems(Update, Self::diagnostic_system);
+
+        #[cfg(feature = "svg")]
+        app.register_diagnostic(Diagnostic::new(Self::SVG_COUNT));
+        #[cfg(feature = "lottie")]
+        app.register_diagnostic(Diagnostic::new(Self::LOTTIE_COUNT));
+    }
+}
+
+impl VelloDiagnosticsPlugin {
+    pub const SCENE_COUNT: DiagnosticPath = DiagnosticPath::const_new("vello_scenes");
+    pub const TEXT_COUNT: DiagnosticPath = DiagnosticPath::const_new("vello_texts");
+    #[cfg(feature = "svg")]
+    pub const SVG_COUNT: DiagnosticPath = DiagnosticPath::const_new("vello_svgs");
+    #[cfg(feature = "lottie")]
+    pub const LOTTIE_COUNT: DiagnosticPath = DiagnosticPath::const_new("vello_lotties");
+
+    fn diagnostic_system(mut diagnostics: Diagnostics, data: Res<VelloFrameData>) {
+        diagnostics.add_measurement(&Self::SCENE_COUNT, || data.n_scenes as f64);
+        diagnostics.add_measurement(&Self::TEXT_COUNT, || data.n_texts as f64);
+        #[cfg(feature = "svg")]
+        diagnostics.add_measurement(&Self::SVG_COUNT, || data.n_svgs as f64);
+        #[cfg(feature = "lottie")]
+        diagnostics.add_measurement(&Self::LOTTIE_COUNT, || data.n_lotties as f64);
+    }
+}

--- a/src/integrations/lottie/plugin.rs
+++ b/src/integrations/lottie/plugin.rs
@@ -1,4 +1,4 @@
-use crate::render::VelatoRenderer;
+use crate::render::{extract::VelloExtractStep, VelatoRenderer};
 
 use super::{
     asset::VelloLottieHandle, asset_loader::VelloLottieLoader, render, systems, VelloLottie,
@@ -34,7 +34,10 @@ impl Plugin for LottieIntegrationPlugin {
 
         render_app
             .init_resource::<VelatoRenderer>()
-            .add_systems(ExtractSchedule, render::extract_lottie_assets)
+            .add_systems(
+                ExtractSchedule,
+                render::extract_lottie_assets.in_set(VelloExtractStep::ExtractAssets),
+            )
             .add_systems(
                 Render,
                 (render::prepare_asset_affines).in_set(RenderSet::Prepare),

--- a/src/integrations/svg/plugin.rs
+++ b/src/integrations/svg/plugin.rs
@@ -1,3 +1,5 @@
+use crate::render::extract::VelloExtractStep;
+
 use super::{asset::VelloSvgHandle, asset_loader::VelloSvgLoader, render, VelloSvg};
 use bevy::{
     prelude::*,
@@ -23,7 +25,10 @@ impl Plugin for SvgIntegrationPlugin {
         };
 
         render_app
-            .add_systems(ExtractSchedule, render::extract_svg_assets)
+            .add_systems(
+                ExtractSchedule,
+                render::extract_svg_assets.in_set(VelloExtractStep::ExtractAssets),
+            )
             .add_systems(
                 Render,
                 (render::prepare_asset_affines,).in_set(RenderSet::Prepare),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod plugin;
 pub use plugin::VelloPlugin;
 
 pub mod debug;
+pub mod diagnostics;
 pub mod integrations;
 pub mod render;
 pub mod text;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub struct VelloTextBundle {
 /// A simple newtype component wrapper for [`vello::Scene`] for rendering.
 #[derive(Component, Default, Clone, Deref, DerefMut)]
 #[require(CoordinateSpace, Transform, Visibility)]
-pub struct VelloScene(vello::Scene);
+pub struct VelloScene(Box<vello::Scene>);
 
 impl VelloScene {
     pub fn new() -> Self {
@@ -90,6 +90,6 @@ impl VelloScene {
 
 impl From<vello::Scene> for VelloScene {
     fn from(scene: vello::Scene) -> Self {
-        Self(scene)
+        Self(Box::new(scene))
     }
 }

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -1,24 +1,36 @@
+use super::VelloFrameData;
 use crate::prelude::*;
 use bevy::{
     prelude::*,
     render::{
-        extract_component::ExtractComponent, sync_world::TemporaryRenderEntity, view::RenderLayers,
-        Extract,
+        camera::ExtractedCamera, extract_component::ExtractComponent,
+        sync_world::TemporaryRenderEntity, view::RenderLayers, Extract, MainWorld,
     },
     window::PrimaryWindow,
 };
 
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
+pub enum VelloExtractStep {
+    // Extract renderable types, e.g. SVG, Lottie, Text, Scenes
+    ExtractAssets,
+    // Synchronize frame data
+    SyncData,
+}
+
 #[derive(Component, Clone)]
-pub struct ExtractedRenderScene {
+pub struct ExtractedVelloScene {
     pub scene: VelloScene,
     pub transform: GlobalTransform,
     pub render_mode: CoordinateSpace,
     pub ui_node: Option<ComputedNode>,
-    pub render_layers: Option<RenderLayers>,
 }
 
 pub fn extract_scenes(
     mut commands: Commands,
+    query_views: Query<
+        (&ExtractedCamera, Option<&RenderLayers>),
+        (With<Camera2d>, With<VelloView>),
+    >,
     query_scenes: Extract<
         Query<
             (
@@ -33,7 +45,15 @@ pub fn extract_scenes(
             Without<SkipEncoding>,
         >,
     >,
+    mut frame_data: ResMut<VelloFrameData>,
 ) {
+    let mut n_scenes = 0;
+
+    // Respect camera ordering
+    let mut views: Vec<(&ExtractedCamera, Option<&RenderLayers>)> =
+        query_views.into_iter().collect();
+    views.sort_by(|(camera_a, _), (camera_b, _)| camera_a.order.cmp(&camera_b.order));
+
     for (
         scene,
         coord_space,
@@ -45,30 +65,41 @@ pub fn extract_scenes(
     ) in query_scenes.iter()
     {
         if view_visibility.get() && inherited_visibility.get() {
-            commands
-                .spawn(ExtractedRenderScene {
-                    transform: *transform,
-                    render_mode: *coord_space,
-                    scene: scene.clone(),
-                    ui_node: ui_node.cloned(),
-                    render_layers: render_layers.cloned(),
-                })
-                .insert(TemporaryRenderEntity);
+            let asset_render_layers = render_layers.unwrap_or_default();
+            for (_, camera_render_layers) in views.iter() {
+                if asset_render_layers.intersects(camera_render_layers.unwrap_or_default()) {
+                    commands
+                        .spawn(ExtractedVelloScene {
+                            transform: *transform,
+                            render_mode: *coord_space,
+                            scene: scene.clone(),
+                            ui_node: ui_node.cloned(),
+                        })
+                        .insert(TemporaryRenderEntity);
+                    n_scenes += 1;
+                    break;
+                }
+            }
         }
     }
+
+    frame_data.n_scenes = n_scenes;
 }
 
 #[derive(Component, Clone)]
-pub struct ExtractedRenderText {
+pub struct ExtractedVelloText {
     pub text: VelloTextSection,
     pub text_anchor: VelloTextAnchor,
     pub transform: GlobalTransform,
     pub render_space: CoordinateSpace,
-    pub render_layers: Option<RenderLayers>,
 }
 
 pub fn extract_text(
     mut commands: Commands,
+    query_views: Query<
+        (&ExtractedCamera, Option<&RenderLayers>),
+        (With<Camera2d>, With<VelloView>),
+    >,
     query_scenes: Extract<
         Query<
             (
@@ -83,7 +114,15 @@ pub fn extract_text(
             Without<SkipEncoding>,
         >,
     >,
+    mut frame_data: ResMut<VelloFrameData>,
 ) {
+    let mut n_texts = 0;
+
+    // Respect camera ordering
+    let mut views: Vec<(&ExtractedCamera, Option<&RenderLayers>)> =
+        query_views.into_iter().collect();
+    views.sort_by(|(camera_a, _), (camera_b, _)| camera_a.order.cmp(&camera_b.order));
+
     for (
         text,
         text_anchor,
@@ -95,17 +134,31 @@ pub fn extract_text(
     ) in query_scenes.iter()
     {
         if view_visibility.get() && inherited_visibility.get() {
-            commands
-                .spawn(ExtractedRenderText {
-                    text: text.clone(),
-                    text_anchor: *text_anchor,
-                    transform: *transform,
-                    render_space: *render_space,
-                    render_layers: render_layers.cloned(),
-                })
-                .insert(TemporaryRenderEntity);
+            let text_render_layers = render_layers.unwrap_or_default();
+            for (_, camera_render_layers) in views.iter() {
+                if text_render_layers.intersects(camera_render_layers.unwrap_or_default()) {
+                    commands
+                        .spawn(ExtractedVelloText {
+                            text: text.clone(),
+                            text_anchor: *text_anchor,
+                            transform: *transform,
+                            render_space: *render_space,
+                        })
+                        .insert(TemporaryRenderEntity);
+                    n_texts += 1;
+                    break;
+                }
+            }
         }
     }
+
+    frame_data.n_texts = n_texts;
+}
+
+/// Synchronize the render world frame data back to the main world.
+pub fn sync_frame_data(render_data: Res<VelloFrameData>, mut world: ResMut<MainWorld>) {
+    let mut main_world_data = world.get_resource_mut::<VelloFrameData>().unwrap();
+    *main_world_data = render_data.clone();
 }
 
 /// A screenspace render target. We use a resizable fullscreen quad.

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -163,6 +163,7 @@ pub(crate) struct VelloCanvasSettings {
 #[derive(Component, Debug, Clone, Copy)]
 pub struct SkipEncoding;
 
+/// Internally used as a prepared render asset.
 #[derive(Clone)]
 pub(crate) enum VelloRenderItem {
     #[cfg(feature = "svg")]
@@ -185,6 +186,11 @@ pub(crate) enum VelloRenderItem {
     },
 }
 
+/// Internally used to buffer sorted assets prepared for the next frame.
+#[derive(Resource, Default, Deref, DerefMut)]
+pub(crate) struct VelloRenderQueue(Vec<VelloRenderItem>);
+
+/// Internally used to track diagnostics.
 #[derive(Resource, ExtractResource, Default, Debug, Clone, Reflect)]
 pub(crate) struct VelloFrameData {
     /// Number of scenes.
@@ -198,6 +204,3 @@ pub(crate) struct VelloFrameData {
     #[cfg(feature = "lottie")]
     pub n_lotties: u32,
 }
-
-#[derive(Resource, Default, Deref, DerefMut)]
-pub(crate) struct VelloRenderQueue(Vec<VelloRenderItem>);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,6 +4,7 @@ use bevy::{
     prelude::*,
     render::{
         extract_component::ExtractComponent,
+        extract_resource::ExtractResource,
         mesh::MeshVertexBufferLayoutRef,
         render_resource::{
             AsBindGroup, RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError,
@@ -15,7 +16,7 @@ use bevy::{
     sprite::{Material2d, Material2dKey},
 };
 use std::sync::{Arc, Mutex};
-use vello::{AaConfig, AaSupport};
+use vello::{kurbo::Affine, AaConfig, AaSupport};
 
 mod plugin;
 mod systems;
@@ -161,3 +162,42 @@ pub(crate) struct VelloCanvasSettings {
 /// Add this to any renderable vello asset to skip encoding that renderable.
 #[derive(Component, Debug, Clone, Copy)]
 pub struct SkipEncoding;
+
+#[derive(Clone)]
+pub(crate) enum VelloRenderItem {
+    #[cfg(feature = "svg")]
+    Svg {
+        affine: Affine,
+        item: crate::integrations::svg::render::ExtractedVelloSvg,
+    },
+    #[cfg(feature = "lottie")]
+    Lottie {
+        affine: Affine,
+        item: crate::integrations::lottie::render::ExtractedLottieAsset,
+    },
+    Scene {
+        affine: Affine,
+        item: extract::ExtractedVelloScene,
+    },
+    Text {
+        affine: Affine,
+        item: extract::ExtractedVelloText,
+    },
+}
+
+#[derive(Resource, ExtractResource, Default, Debug, Clone, Reflect)]
+pub(crate) struct VelloFrameData {
+    /// Number of scenes.
+    pub n_scenes: u32,
+    /// Number of text sections.
+    pub n_texts: u32,
+    /// Number of SVGs.
+    #[cfg(feature = "svg")]
+    pub n_svgs: u32,
+    /// Number of Lotties.
+    #[cfg(feature = "lottie")]
+    pub n_lotties: u32,
+}
+
+#[derive(Resource, Default, Deref, DerefMut)]
+pub(crate) struct VelloRenderQueue(Vec<VelloRenderItem>);

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -1,14 +1,11 @@
 use super::{
-    extract::{ExtractedPixelScale, ExtractedRenderScene, ExtractedRenderText},
+    extract::{ExtractedPixelScale, ExtractedVelloScene, ExtractedVelloText},
     VelloView,
 };
 use crate::CoordinateSpace;
 use bevy::{
     prelude::*,
-    render::{
-        camera::ExtractedCamera,
-        view::{ExtractedView, RenderLayers},
-    },
+    render::{camera::ExtractedCamera, view::ExtractedView},
 };
 use vello::kurbo::Affine;
 
@@ -33,25 +30,15 @@ pub trait PrepareRenderInstance {
 
 pub fn prepare_scene_affines(
     mut commands: Commands,
-    views: Query<
-        (&ExtractedCamera, &ExtractedView, Option<&RenderLayers>),
-        (With<Camera2d>, With<VelloView>),
-    >,
-    render_entities: Query<(Entity, &ExtractedRenderScene)>,
+    views: Query<(&ExtractedCamera, &ExtractedView), (With<Camera2d>, With<VelloView>)>,
+    render_entities: Query<(Entity, &ExtractedVelloScene)>,
 ) {
-    for (camera, view, maybe_camera_layers) in views.iter() {
-        let camera_render_layers = maybe_camera_layers.unwrap_or_default();
+    for (camera, view) in views.iter() {
         let size_pixels: UVec2 = camera.physical_viewport_size.unwrap();
         let (pixels_x, pixels_y) = (size_pixels.x as f32, size_pixels.y as f32);
 
         // Render scenes
         for (entity, render_entity) in render_entities.iter() {
-            let maybe_entity_layers = render_entity.render_layers.clone();
-            let entity_render_layers = maybe_entity_layers.unwrap_or_default();
-            if !camera_render_layers.intersects(&entity_render_layers) {
-                continue;
-            }
-
             let ndc_to_pixels_matrix = Mat4::from_cols_array_2d(&[
                 [pixels_x / 2.0, 0.0, 0.0, pixels_x / 2.0],
                 [0.0, pixels_y / 2.0, 0.0, pixels_y / 2.0],
@@ -124,25 +111,15 @@ pub fn prepare_scene_affines(
 
 pub fn prepare_text_affines(
     mut commands: Commands,
-    views: Query<
-        (&ExtractedCamera, &ExtractedView, Option<&RenderLayers>),
-        (With<Camera2d>, With<VelloView>),
-    >,
-    render_entities: Query<(Entity, &ExtractedRenderText)>,
+    views: Query<(&ExtractedCamera, &ExtractedView), (With<Camera2d>, With<VelloView>)>,
+    render_entities: Query<(Entity, &ExtractedVelloText)>,
     pixel_scale: Res<ExtractedPixelScale>,
 ) {
-    for (camera, view, maybe_camera_layers) in views.iter() {
-        let camera_render_layers = maybe_camera_layers.unwrap_or_default();
+    for (camera, view) in views.iter() {
         let size_pixels: UVec2 = camera.physical_viewport_size.unwrap();
         let (pixels_x, pixels_y) = (size_pixels.x as f32, size_pixels.y as f32);
 
         for (entity, render_entity) in render_entities.iter() {
-            let maybe_entity_layers = render_entity.render_layers.clone();
-            let entity_render_layers = maybe_entity_layers.unwrap_or_default();
-            if !camera_render_layers.intersects(&entity_render_layers) {
-                continue;
-            }
-
             let ndc_to_pixels_matrix = Mat4::from_cols_array_2d(&[
                 [pixels_x / 2.0, 0.0, 0.0, pixels_x / 2.0],
                 [0.0, pixels_y / 2.0, 0.0, pixels_y / 2.0],


### PR DESCRIPTION
PR adds a new `VelloDiagnosticsPlugin` which tracks the number of SVG, Text, Lottie, and Scene assets being rendered each frame.

To do this, backend implementation was modified:
- Extracting now optimizes away assets not intersecting with a camera's render layers. (previously done in Render; this had to be moved to Extract since Extract is the only schedule with both access to the main and render world, where we synchronize back the frame data. This should be an improvement)
- Rendering now occurs in 2 steps: Sorting assets, then Rendering.

As well, a new example has been added, which shows a diagnostic:
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/6d9898d0-49af-4d2a-b0cd-a970cc402954" />
