### PR TITLE
Update bevy dependency to 0.15.3 and fixed lottie examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/linebender/bevy_vello"
 
 [workspace.dependencies]
-bevy = { version = "0.15.2", default-features = false, features = [
+bevy = { version = "0.15.3", default-features = false, features = [
   "bevy_asset",
   "bevy_winit",
   "bevy_window",

--- a/examples/lottie/Cargo.toml
+++ b/examples/lottie/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy_vello = { path = "../../", features = ["lottie"] }
+bevy_vello = { path = "../../", features = ["lottie", "svg"] }
 bevy = { workspace = true, features = ["bevy_gizmos"] }

--- a/examples/lottie_player/Cargo.toml
+++ b/examples/lottie_player/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy_vello = { path = "../../", features = ["lottie"] }
+bevy_vello = { path = "../../", features = ["lottie", "svg"] }
 bevy = { workspace = true }
 bevy_pancam = { version = "0.17.0", features = ["bevy_egui"] }
 bevy_egui = "0.32.0"


### PR DESCRIPTION
Issue: https://github.com/linebender/bevy_vello/issues/144
- Updated bevy dependency to latest version 0.15.3

Fix: https://github.com/linebender/bevy_vello/issues/146
- Added missing svg feature to lottie and lottie_player example