### PR TITLE
fix: examples/headless - added missing 'png' feature 

### DIFF
--- a/examples/headless/Cargo.toml
+++ b/examples/headless/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bevy_vello = { path = "../../" }
-bevy = { workspace = true }
+bevy = { workspace = true, features = ["png"] }


### PR DESCRIPTION
fix: examples/headless: added missing png feature for bevy dependency to Cargo.toml.