### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 -->
 
-The latest published Bevy Vello release is [0.7.1](#071---2025-03-12) which was released on 2025-03-12.
-You can find its changes [documented below](#071---2025-03-12).
+The latest published Bevy Vello release is [0.7.1](#080---2025-04-29) which was released on 2025-04-29.
+You can find its changes [documented below](#080---2025-04-29).
 
 ## [Unreleased]
+
+This release supports Bevy version 0.15 and has an [MSRV][] of 1.86.
+
+## [0.8.0] - 2025-04-29
 
 This release supports Bevy version 0.15 and has an [MSRV][] of 1.85.
 
@@ -300,7 +304,8 @@ This release supports Bevy version 0.13 and has an [MSRV][] of 1.77.
 
 [@simbleau]: https://github.com/simbleau
 
-[Unreleased]: https://github.com/linebender/bevy_vello/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/linebender/bevy_vello/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/linebender/bevy_vello/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/linebender/bevy_vello/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/linebender/bevy_vello/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/linebender/bevy_vello/compare/v0.6.0...v0.6.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_vello"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "parley",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "cube3d"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -1960,7 +1960,7 @@ checksum = "edf215dbb8cb1409cca7645aaed35f9e39fb0a21855bba1ac48bc0334903bf66"
 
 [[package]]
 name = "diagnostics"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -2033,7 +2033,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "drag_n_drop"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_async_task",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "headless"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "lottie"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "lottie_player"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_egui",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "lottie_ui"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -4275,7 +4275,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "render_layers"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "scene"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "scene_ui"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "svg"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -4716,7 +4716,7 @@ checksum = "ce5d813d71d82c4cbc1742135004e4a79fd870214c155443451c139c9470a0aa"
 
 [[package]]
 name = "svg_ui"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "text"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bevy_vello",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.7.1"
+version = "0.8.0"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/linebender/bevy_vello"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ cargo run -p <example name>
 
 |bevy|bevy_vello|vello|
 |---|---|---|
-|0.15|0.7,main|0.4|
+|0.16|Not yet ready|Not yet ready|
+|0.15|0.7-0.8,main|0.4|
 |0.14|0.5-0.6|0.3|
 |0.13|0.1-0.4|0.2|
 |< 0.13| unsupported | |


### PR DESCRIPTION
This will be the last release on bevy 0.15