### PR TITLE
Segregate world and screen space when sorting render items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The latest published Bevy Vello release is [0.10.0](#0100---2025-06-23) which wa
 You can find its changes [documented below](#0100---2025-06-23).
 
 ## [Unreleased]
+
 This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,13 @@ The latest published Bevy Vello release is [0.10.0](#0100---2025-06-23) which wa
 You can find its changes [documented below](#0100---2025-06-23).
 
 ## [Unreleased]
-
 This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.
-
-### Added
-
-- `get_viewport_size` gets the correct camera viewport size (defaulting to window size if not present) which should be used when creating the render texture
-
-### Changed
-
-- `resize_rendertargets` now uses `get_viewport_size` when resizing the render texture
-- `setup_ss_rendertarget` now uses `get_viewport_size` when creating the render texture
-- world and screen render items are now sorted separately and then combined, world first and screen last.
 
 ### Fixed
 
 - `ZIndex` is now respected by vello render items that have a `Node` or `VelloScreenSpace` component.
+- Screen space items (those with `Node` or `VelloScreenSpace`) now always render on top.
+- The vello canvas now respects the correct camera viewport size (defaulting to window size if not present) which should be used when creating the render texture
 
 ## [0.10.0] - 2025-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.
 
 - `resize_rendertargets` now uses `get_viewport_size` when resizing the render texture
 - `setup_ss_rendertarget` now uses `get_viewport_size` when creating the render texture
-- world and screen render items are now sorted seperately and then combined, to render world items first and screen items last.
+- world and screen render items are now sorted separately and then combined, to render world items first and screen items last.
 
 ## [0.10.0] - 2025-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.
 
 - `resize_rendertargets` now uses `get_viewport_size` when resizing the render texture
 - `setup_ss_rendertarget` now uses `get_viewport_size` when creating the render texture
-- world and screen render items are now sorted separately and then combined, to render world items first and screen items last.
+- world and screen render items are now sorted separately and then combined, world first and screen last.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,16 @@ This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.
 ### Added
 
 - `get_viewport_size` gets the correct camera viewport size (defaulting to window size if not present) which should be used when creating the render texture
-- adds `ZIndex` support to vello render items that have either a bevy_ui `Node` or `VelloScreenSpace` component.
 
 ### Changed
 
 - `resize_rendertargets` now uses `get_viewport_size` when resizing the render texture
 - `setup_ss_rendertarget` now uses `get_viewport_size` when creating the render texture
 - world and screen render items are now sorted separately and then combined, to render world items first and screen items last.
+
+### Fixed
+
+- `ZIndex` is now respected by vello render items that have a `Node` or `VelloScreenSpace` component.
 
 ## [0.10.0] - 2025-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@ This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.
 ### Added
 
 - `get_viewport_size` gets the correct camera viewport size (defaulting to window size if not present) which should be used when creating the render texture
+- adds `ZIndex` support to vello render items that have either a bevy_ui `Node` or `VelloScreenSpace` component.
 
 ### Changed
 
 - `resize_rendertargets` now uses `get_viewport_size` when resizing the render texture
 - `setup_ss_rendertarget` now uses `get_viewport_size` when creating the render texture
+- world and screen render items are now sorted seperately and then combined, to render world items first and screen items last.
 
 ## [0.10.0] - 2025-06-23
 
@@ -360,7 +362,9 @@ This release supports Bevy version 0.13 and has an [MSRV][] of 1.77.
 - Initial release
 
 [#77]: https://github.com/linebender/bevy_vello/pull/77
+
 [@simbleau]: https://github.com/simbleau
+
 [Unreleased]: https://github.com/linebender/bevy_vello/compare/v0.10.0...HEAD
 [0.10.0]: https://github.com/linebender/bevy_vello/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/linebender/bevy_vello/compare/v0.8.0...v0.9.0
@@ -384,4 +388,5 @@ This release supports Bevy version 0.13 and has an [MSRV][] of 1.77.
 [0.1.2]: https://github.com/linebender/bevy_vello/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/linebender/bevy_vello/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/linebender/bevy_vello/releases/tag/v0.1.0
+
 [MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/src/integrations/lottie/render.rs
+++ b/src/integrations/lottie/render.rs
@@ -32,6 +32,7 @@ pub struct ExtractedLottieAsset {
     pub playhead: f64,
     pub screen_space: Option<VelloScreenSpace>,
     pub skip_scaling: Option<SkipScaling>,
+    pub z_index: Option<ZIndex>,
 }
 
 pub fn extract_lottie_assets(
@@ -54,6 +55,7 @@ pub fn extract_lottie_assets(
                 &InheritedVisibility,
                 Option<&VelloScreenSpace>,
                 Option<&SkipScaling>,
+                Option<&ZIndex>,
             ),
             Without<SkipEncoding>,
         >,
@@ -79,6 +81,7 @@ pub fn extract_lottie_assets(
         inherited_visibility,
         screen_space,
         skip_scaling,
+        z_index,
     ) in query_vectors.iter()
     {
         // Skip if visibility conditions are not met
@@ -106,6 +109,7 @@ pub fn extract_lottie_assets(
                     ui_node: ui_node.cloned(),
                     screen_space: screen_space.cloned(),
                     skip_scaling: skip_scaling.cloned(),
+                    z_index: z_index.cloned(),
                 })
                 .insert(TemporaryRenderEntity);
             n_lotties += 1;

--- a/src/integrations/svg/render.rs
+++ b/src/integrations/svg/render.rs
@@ -31,6 +31,7 @@ pub struct ExtractedVelloSvg {
     pub alpha: f32,
     pub screen_space: Option<VelloScreenSpace>,
     pub skip_scaling: Option<SkipScaling>,
+    pub z_index: Option<ZIndex>,
 }
 
 pub fn extract_svg_assets(
@@ -51,6 +52,7 @@ pub fn extract_svg_assets(
                 &InheritedVisibility,
                 Option<&VelloScreenSpace>,
                 Option<&SkipScaling>,
+                Option<&ZIndex>,
             ),
             Without<SkipEncoding>,
         >,
@@ -74,6 +76,7 @@ pub fn extract_svg_assets(
         inherited_visibility,
         screen_space,
         skip_scaling,
+        z_index,
     ) in query_vectors.iter()
     {
         // Skip if visibility conditions are not met
@@ -99,6 +102,7 @@ pub fn extract_svg_assets(
                     alpha: asset.alpha,
                     screen_space: screen_space.cloned(),
                     skip_scaling: skip_scaling.cloned(),
+                    z_index: z_index.cloned(),
                 })
                 .insert(TemporaryRenderEntity);
             n_svgs += 1;

--- a/src/integrations/text/render.rs
+++ b/src/integrations/text/render.rs
@@ -26,6 +26,7 @@ pub struct ExtractedVelloText {
     pub ui_node: Option<ComputedNode>,
     pub screen_space: Option<VelloScreenSpace>,
     pub skip_scaling: Option<SkipScaling>,
+    pub z_index: Option<ZIndex>,
 }
 
 pub fn extract_text(
@@ -46,6 +47,7 @@ pub fn extract_text(
                 Option<&ComputedNode>,
                 Option<&VelloScreenSpace>,
                 Option<&SkipScaling>,
+                Option<&ZIndex>,
             ),
             Without<SkipEncoding>,
         >,
@@ -69,6 +71,7 @@ pub fn extract_text(
         ui_node,
         screen_space,
         skip_scaling,
+        z_index,
     ) in query_scenes.iter()
     {
         // Skip if visibility conditions are not met
@@ -93,6 +96,7 @@ pub fn extract_text(
                     ui_node: ui_node.cloned(),
                     screen_space: screen_space.cloned(),
                     skip_scaling: skip_scaling.cloned(),
+                    z_index: z_index.cloned(),
                 })
                 .insert(TemporaryRenderEntity);
             n_texts += 1;

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -24,6 +24,7 @@ pub struct ExtractedVelloScene {
     pub ui_node: Option<ComputedNode>,
     pub screen_space: Option<VelloScreenSpace>,
     pub skip_scaling: Option<SkipScaling>,
+    pub z_index: Option<ZIndex>,
 }
 
 pub fn extract_scenes(
@@ -43,6 +44,7 @@ pub fn extract_scenes(
                 Option<&RenderLayers>,
                 Option<&VelloScreenSpace>,
                 Option<&SkipScaling>,
+                Option<&ZIndex>,
             ),
             Without<SkipEncoding>,
         >,
@@ -64,6 +66,7 @@ pub fn extract_scenes(
         render_layers,
         screen_space,
         skip_scaling,
+        z_index,
     ) in query_scenes.iter()
     {
         // Skip if visibility conditions are not met
@@ -83,6 +86,7 @@ pub fn extract_scenes(
                     ui_node: ui_node.cloned(),
                     screen_space: screen_space.cloned(),
                     skip_scaling: skip_scaling.cloned(),
+                    z_index: z_index.cloned(),
                 })
                 .insert(TemporaryRenderEntity);
             n_scenes += 1;

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -180,8 +180,7 @@ pub fn sort_render_items(
     final_render_queue.clear();
 
     // Reserve space for the final render queue to avoid reallocations
-    let total = world_render_queue.len() + screen_render_queue.len();
-    final_render_queue.reserve(total);
+    final_render_queue.reserve(n_render_items);
     final_render_queue.extend(
         world_render_queue
             .into_iter()

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -66,7 +66,9 @@ pub fn sort_render_items(
     mut final_render_queue: ResMut<VelloRenderQueue>,
     frame_data: ResMut<VelloEntityCountData>,
 ) {
-    let mut n_render_items: usize = frame_data.n_scenes as usize;
+    let mut n_render_items: usize = 0;
+
+    n_render_items += frame_data.n_scenes as usize;
 
     #[cfg(feature = "text")]
     {

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -66,9 +66,22 @@ pub fn sort_render_items(
     mut final_render_queue: ResMut<VelloRenderQueue>,
     frame_data: ResMut<VelloEntityCountData>,
 ) {
-    let n_render_items: usize =
-        (frame_data.n_scenes + frame_data.n_texts + frame_data.n_svgs + frame_data.n_lotties)
-            as usize;
+    let mut n_render_items: usize = frame_data.n_scenes as usize;
+
+    #[cfg(feature = "text")]
+    {
+        n_render_items += frame_data.n_texts as usize;
+    }
+
+    #[cfg(feature = "svg")]
+    {
+        n_render_items += frame_data.n_svgs as usize;
+    }
+
+    #[cfg(feature = "lottie")]
+    {
+        n_render_items += frame_data.n_lotties as usize;
+    }
 
     // Reserve space for the render queues to avoid reallocations
     let mut world_render_queue: Vec<(f32, VelloRenderItem)> = Vec::with_capacity(n_render_items);

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -64,9 +64,15 @@ pub fn sort_render_items(
     #[cfg(feature = "svg")] view_svgs: Query<(&PreparedAffine, &ExtractedVelloSvg)>,
     #[cfg(feature = "lottie")] view_lotties: Query<(&PreparedAffine, &ExtractedLottieAsset)>,
     mut final_render_queue: ResMut<VelloRenderQueue>,
+    frame_data: ResMut<VelloEntityCountData>,
 ) {
-    let mut world_render_queue: Vec<(f32, VelloRenderItem)> = vec![];
-    let mut screen_render_queue: Vec<(f32, VelloRenderItem)> = vec![];
+    let n_render_items: usize =
+        (frame_data.n_scenes + frame_data.n_texts + frame_data.n_svgs + frame_data.n_lotties)
+            as usize;
+
+    // Reserve space for the render queues to avoid reallocations
+    let mut world_render_queue: Vec<(f32, VelloRenderItem)> = Vec::with_capacity(n_render_items);
+    let mut screen_render_queue: Vec<(f32, VelloRenderItem)> = Vec::with_capacity(n_render_items);
 
     #[cfg(feature = "svg")]
     for (&affine, asset) in view_svgs.iter() {


### PR DESCRIPTION
Should close: https://github.com/linebender/bevy_vello/issues/164

Resolves the issue where world and screen render items are mixed together, now world is rendered first and screen is rendered ontop.