### PR TITLE
Calculate text section content size improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ You can find its changes [documented below](#0101---2025-06-27).
 
 This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.
 
+### Added
+
+- System to calculate the content size of `VelloTextSection` when `VelloWorldScale` is changed.
+
+### Fixed
+
+- Systems that calculate the content size of `VelloTextSection` now run in the `PostUpdate` system set to ensure that all `Handle<VelloFont>` that are created in the same frame are loaded before calculating the content size.
+
 ## [0.10.1] - 2025-06-27
 
 This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,6 @@ You can find its changes [documented below](#0101---2025-06-27).
 
 This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.
 
-### Added
-
-- System to calculate the content size of `VelloTextSection` when `VelloWorldScale` is changed.
-
 ### Fixed
 
 - Systems that calculate the content size of `VelloTextSection` now run in the `PostUpdate` system set to ensure that all `Handle<VelloFont>` that are created in the same frame are loaded before calculating the content size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This release supports Bevy version 0.16 and has an [MSRV][] of 1.87.
 
 ### Fixed
 
-- Systems that calculate the content size of `VelloTextSection` now run in the `PostUpdate` system set to ensure that all `Handle<VelloFont>` that are created in the same frame are loaded before calculating the content size.
+- Systems that calculate the content size of `VelloTextSection` now run in the `PostUpdate` schedule to ensure that all `Handle<VelloFont>` are loaded before calculating the content size.
 
 ## [0.10.1] - 2025-06-27
 

--- a/src/integrations/text/plugin.rs
+++ b/src/integrations/text/plugin.rs
@@ -24,7 +24,7 @@ impl Plugin for VelloTextIntegrationPlugin {
             .add_plugins(RenderAssetPlugin::<VelloFont>::default());
 
         // PostUpdate is used to ensure that the font handles are available if the consumer
-        // of the API is createing a font handle in the same frame.
+        // of the API is creating a font handle in the same frame.
         app.add_systems(
             PostUpdate,
             (

--- a/src/integrations/text/plugin.rs
+++ b/src/integrations/text/plugin.rs
@@ -23,8 +23,8 @@ impl Plugin for VelloTextIntegrationPlugin {
             .init_asset_loader::<VelloFontLoader>()
             .add_plugins(RenderAssetPlugin::<VelloFont>::default());
 
-        // PostUpdate is used to ensure that the font handles are available if the consumer
-        // of the API is creating a font handle in the same frame.
+        // Intentionally run in `PostUpdate` due to race condition behavior when modifying
+        // `VelloTextStyle` font in the same frame.
         app.add_systems(
             PostUpdate,
             (

--- a/src/integrations/text/plugin.rs
+++ b/src/integrations/text/plugin.rs
@@ -10,10 +10,9 @@ use super::{
     vello_text::{
         calculate_text_section_content_size_on_change,
         calculate_text_section_content_size_on_screen_scale_change,
-        calculate_text_section_content_size_on_world_scale_change,
     },
 };
-use crate::render::{VelloScreenScale, VelloWorldScale, extract::VelloExtractStep};
+use crate::render::{VelloScreenScale, extract::VelloExtractStep};
 
 pub struct VelloTextIntegrationPlugin;
 
@@ -31,8 +30,6 @@ impl Plugin for VelloTextIntegrationPlugin {
                 calculate_text_section_content_size_on_change,
                 calculate_text_section_content_size_on_screen_scale_change
                     .run_if(resource_changed::<VelloScreenScale>),
-                calculate_text_section_content_size_on_world_scale_change
-                    .run_if(resource_changed::<VelloWorldScale>),
             ),
         );
 

--- a/src/integrations/text/vello_text.rs
+++ b/src/integrations/text/vello_text.rs
@@ -241,12 +241,12 @@ pub fn calculate_text_section_content_size_on_change(
     let (camera, camera_transform) = *camera;
 
     for (mut content_size, text, gtransform) in text_q.iter_mut() {
-        if let Some(rect) = text.bb_in_screen_space(
-            fonts.get(&text.style.font).unwrap(),
-            gtransform,
-            camera,
-            camera_transform,
-        ) {
+        let Some(font) = fonts.get(&text.style.font) else {
+            warn!("VelloTextSection: font {:?} not found", text.style.font);
+            continue;
+        };
+
+        if let Some(rect) = text.bb_in_screen_space(font, gtransform, camera, camera_transform) {
             let size = rect.size();
             let width = text.width.unwrap_or(size.x.abs().mul(screen_scale.0));
             let height = text.height.unwrap_or(size.y.abs().mul(screen_scale.0));
@@ -267,12 +267,12 @@ pub fn calculate_text_section_content_size(
     let (camera, camera_transform) = *camera;
 
     for (mut content_size, text, gtransform) in text_q.iter_mut() {
-        if let Some(rect) = text.bb_in_screen_space(
-            fonts.get(&text.style.font).unwrap(),
-            gtransform,
-            camera,
-            camera_transform,
-        ) {
+        let Some(font) = fonts.get(&text.style.font) else {
+            warn!("VelloTextSection: font {:?} not found", text.style.font);
+            continue;
+        };
+
+        if let Some(rect) = text.bb_in_screen_space(font, gtransform, camera, camera_transform) {
             let size = rect.size();
             let width = text.width.unwrap_or(size.x.abs().mul(screen_scale.0));
             let height = text.height.unwrap_or(size.y.abs().mul(screen_scale.0));

--- a/src/integrations/text/vello_text.rs
+++ b/src/integrations/text/vello_text.rs
@@ -8,8 +8,8 @@ use bevy::{
 use vello::peniko::{self, Brush};
 
 use crate::{
-    VelloFont, VelloScreenSpace,
-    render::{VelloScreenScale, VelloView, VelloWorldScale},
+    VelloFont,
+    render::{VelloScreenScale, VelloView},
 };
 
 #[derive(Component, Default, Clone)]
@@ -259,10 +259,7 @@ pub fn calculate_text_section_content_size_on_change(
 }
 
 pub fn calculate_text_section_content_size_on_screen_scale_change(
-    mut text_q: Query<
-        (&mut ContentSize, &mut VelloTextSection, &GlobalTransform),
-        Or<(With<VelloScreenSpace>, With<bevy::ui::Node>)>,
-    >,
+    mut text_q: Query<(&mut ContentSize, &mut VelloTextSection, &GlobalTransform)>,
     camera: Single<(&Camera, &GlobalTransform), With<VelloView>>,
     fonts: Res<Assets<VelloFont>>,
     screen_scale: Res<VelloScreenScale>,
@@ -284,29 +281,5 @@ pub fn calculate_text_section_content_size_on_screen_scale_change(
             });
             content_size.set(measure);
         }
-    }
-}
-
-pub fn calculate_text_section_content_size_on_world_scale_change(
-    mut text_q: Query<
-        (&mut ContentSize, &mut VelloTextSection, &GlobalTransform),
-        (Without<VelloScreenSpace>, Without<bevy::ui::Node>),
-    >,
-    fonts: Res<Assets<VelloFont>>,
-    world_scale: Res<VelloWorldScale>,
-) {
-    for (mut content_size, text, gtransform) in text_q.iter_mut() {
-        let Some(font) = fonts.get(&text.style.font) else {
-            continue;
-        };
-
-        let rect = text.bb_in_world_space(font, gtransform);
-        let size = rect.size();
-        let width = text.width.unwrap_or(size.x.abs().mul(world_scale.0));
-        let height = text.height.unwrap_or(size.y.abs().mul(world_scale.0));
-        let measure = NodeMeasure::Fixed(bevy::ui::FixedMeasure {
-            size: Vec2::new(width, height),
-        });
-        content_size.set(measure);
     }
 }

--- a/src/integrations/text/vello_text.rs
+++ b/src/integrations/text/vello_text.rs
@@ -8,7 +8,7 @@ use bevy::{
 use vello::peniko::{self, Brush};
 
 use crate::{
-    VelloFont,
+    VelloFont, VelloScreenSpace,
     render::{VelloScreenScale, VelloView, VelloWorldScale},
 };
 
@@ -259,7 +259,10 @@ pub fn calculate_text_section_content_size_on_change(
 }
 
 pub fn calculate_text_section_content_size_on_screen_scale_change(
-    mut text_q: Query<(&mut ContentSize, &mut VelloTextSection, &GlobalTransform)>,
+    mut text_q: Query<
+        (&mut ContentSize, &mut VelloTextSection, &GlobalTransform),
+        Or<(With<VelloScreenSpace>, With<bevy::ui::Node>)>,
+    >,
     camera: Single<(&Camera, &GlobalTransform), With<VelloView>>,
     fonts: Res<Assets<VelloFont>>,
     screen_scale: Res<VelloScreenScale>,
@@ -285,7 +288,10 @@ pub fn calculate_text_section_content_size_on_screen_scale_change(
 }
 
 pub fn calculate_text_section_content_size_on_world_scale_change(
-    mut text_q: Query<(&mut ContentSize, &mut VelloTextSection, &GlobalTransform)>,
+    mut text_q: Query<
+        (&mut ContentSize, &mut VelloTextSection, &GlobalTransform),
+        (Without<VelloScreenSpace>, Without<bevy::ui::Node>),
+    >,
     fonts: Res<Assets<VelloFont>>,
     world_scale: Res<VelloWorldScale>,
 ) {


### PR DESCRIPTION
Found a few issues in the calculate text section size systems that this fixes.

1. Because the systems ran in the `Update` schedule, sometimes when changing or adding a `Handle<VelloFont>` to a `VelloTextStyle`, the font would be assigned after calculating the content size.
2. The calculate content size systems previously panicked if the font was missing, now we gracefully `warn!` instead
3. ~~We did not care about world scale scaling for text sections, I've added the system and updated the text section queries to select text sections for the correct space.~~ removed after some reflection, makes no sense to have it in the plugin