### PR TITLE
Make text `render` function public

### DIFF
--- a/src/integrations/text/font.rs
+++ b/src/integrations/text/font.rs
@@ -87,7 +87,7 @@ impl VelloFont {
         })
     }
 
-    pub(crate) fn render(
+    pub fn render(
         &self,
         scene: &mut Scene,
         mut transform: Affine,


### PR DESCRIPTION
A `VelloTextSection` must currently be added to an entity and spawned in the world to be rendered, unlike `impl Shape` which can be encoded to a scene at any time. This has made it difficult to use text in my immediate mode application.

This PR changes the visibility of the `render` function on a `VelloFont` from `pub(crate)` to `pub`. As far as I am aware this change doesn't cause any problems, and should work as part of the API without any modifications.

PS: This is my first ever pull request, so if anything here is a faux pas I would appreciate the feedback.